### PR TITLE
v1.0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ## ⬇️ Download
 
-- macOS: <a href="https://github.com/ModuleArt/plain-color/releases/download/v1.0.8/PlainColor_1.0.8_aarch64.dmg">dmg</a>
+- macOS: <a href="https://github.com/ModuleArt/plain-color/releases/download/v1.0.9/PlainColor_1.0.9_aarch64.dmg">dmg</a>
 - Windows: exe | microsoft store | chocolatey - Coming soon...
 - Linux: flathub | appimage | deb - Coming soon...
 

--- a/README.md
+++ b/README.md
@@ -95,3 +95,4 @@ If you want to report a bug, first, thank you, that helps us a lot. Please open 
 - [Aperture size](https://github.com/ModuleArt/plain-color/pull/9#issuecomment-2599870209)
 - Improve list performance (infinite scroll)
 - Move picker with arrows (step = 1px), make sure it cannot be out of screen bounds
+- Settings: Add "Reset to defaults" button

--- a/README.md
+++ b/README.md
@@ -96,3 +96,5 @@ If you want to report a bug, first, thank you, that helps us a lot. Please open 
 - Improve list performance (infinite scroll)
 - Move picker with arrows (step = 1px), make sure it cannot be out of screen bounds
 - Settings: Add "Reset to defaults" button
+- Instant copy shortcut `CommandOrControl+Alt+C`
+- Instant pick shortcut `CommandOrControl+Shift+C`

--- a/README.md
+++ b/README.md
@@ -62,10 +62,6 @@ If you want to report a bug, first, thank you, that helps us a lot. Please open 
 
 - Add ability to reorder colors
 - More color formats:
-  - Common:
-    - 🖥️ RGB/RGBA from 0 to 1 `0,36; 0,18; 0,57`
-    - 🎨 HSB/HSV `268, 69, 57`
-    - 💈 Oklab `oklch(40.1% 0.123 21.57)`
   - Native:
     - 🖥️ NSColor RGB
     - 🖥️ NSColor HSB
@@ -80,6 +76,7 @@ If you want to report a bug, first, thank you, that helps us a lot. Please open 
     - 📱 Android RGB/ARGB
   - Custom color formatter
 - Add ability to change global shortcuts
+- Export to image (with preview, mb use canvas)
 - Add picker sound (Funny mouth sound, with ability to turn off)
 - New button pressed animation: scale down
 - Control Select with arrows up/down

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@
 
 - 🔍 <b>Picker</b> - Pick a color from your screen with advanced magnifying glass
 - 🎨 <b>Custom palettes</b> - Organize your colors with palettes. Name colors and add them to palettes to use in your projects
-  - Export palette to `JSON` `CSS / SASS variables` `JavaScript object`
-  - Import colors from `JSON` `Tailwind CSS default colors`
+  - Export palette to `JSON` `CSS or SASS variables` `JavaScript object`
+  - Import `JSON` `Tailwind CSS colors` `Material UI colors` `Apple colors`
 - 📋 <b>A lot of color formats</b> - Copy your colors as:
   - `#HEX` `HEX` `#hex` `hex`
   - `rgb()` `R,G,B` `color(display-p3)`
@@ -62,6 +62,15 @@ If you want to report a bug, first, thank you, that helps us a lot. Please open 
 
 - Add ability to reorder colors
 - More color formats:
+  - Common:
+    - Oklab `oklch(40.1% 0.123 21.57)`
+    - HSB/HSV `268, 69, 57`
+    - RGB/RGBA from 0 to 1 `0,36; 0,18; 0,57`
+    - LAB
+    - RAL
+    - HKS
+    - COPIC
+    - Prismacolor
   - Native:
     - 🖥️ NSColor RGB
     - 🖥️ NSColor HSB
@@ -80,3 +89,9 @@ If you want to report a bug, first, thank you, that helps us a lot. Please open 
 - Add picker sound (Funny mouth sound, with ability to turn off)
 - New button pressed animation: scale down
 - Control Select with arrows up/down
+- Search for colors in palette
+- Fix: Sometimes the cursor is not visible - Hide cursor with `set_cursor_visible` ([issue](https://github.com/tauri-apps/tauri/issues/10231))
+- <a href="https://v2.tauri.app/plugin/updater/">Add app updater</a>
+- [Aperture size](https://github.com/ModuleArt/plain-color/pull/9#issuecomment-2599870209)
+- Improve list performance (infinite scroll)
+- Move picker with arrows (step = 1px), make sure it cannot be out of screen bounds

--- a/README.md
+++ b/README.md
@@ -24,15 +24,15 @@
 ## ⬇️ Download
 
 - macOS: <a href="https://github.com/ModuleArt/plain-color/releases/download/v1.0.9/PlainColor_1.0.9_aarch64.dmg">dmg</a>
-- Windows: exe | microsoft store | chocolatey - Coming soon...
-- Linux: flathub | appimage | deb - Coming soon...
+- Windows: exe | microsoft store - Coming soon...
+- Linux: deb | flathub - Coming soon...
 
 ## 🚀 Features
 
 - 🔍 <b>Picker</b> - Pick a color from your screen with advanced magnifying glass
 - 🎨 <b>Custom palettes</b> - Organize your colors with palettes. Name colors and add them to palettes to use in your projects
-  - Export palette to `JSON` `CSS or SASS variables` `JavaScript object`
-  - Import `JSON` `Tailwind CSS colors` `Material UI colors` `Apple colors`
+  - Export palette to `JSON` `Apple Color List (.clr)` `CSS or SASS variables` `JavaScript object`
+  - Import `JSON` `Apple Color List (.clr)` `Tailwind CSS colors` `Material UI colors` `Apple colors`
 - 📋 <b>A lot of color formats</b> - Copy your colors as:
   - `#HEX` `HEX` `#hex` `hex`
   - `rgb()` `R,G,B` `color(display-p3)`

--- a/README.md
+++ b/README.md
@@ -58,28 +58,8 @@ If you want to report a bug, first, thank you, that helps us a lot. Please open 
 
 ## 🔮 Roadmap
 
-### v1.0.9
-
-- ❗ Check if PlainColor JSON is correctly typed so it cannot broke the app
-- ❗ Fix: All new colors are named as Main Shaft
-- ❗ Settings: Add "Reset to defaults" button
-- ❗ Improve list performance (infinite scroll)
-- ❗ Fix: Color/Palette name white-space
-- ❗ Fix context menu height (check on different window heights)
-- ❗ Hide context menu on scroll
-- ❗ Animation on export palette content copied
-- ❗ Fix: Cannot copy/select text in inputs/textareas
-- ❗ ColorCard: Add ability to type/paste HEX value
-- Picker: Pinch to zoom
-- Move picker with arrows (step = 1px), make sure it cannot be out of screen bounds
-- Instant copy shortcut `CommandOrControl+Shift+C`
-- Export to image (with preview, mb use canvas)
-- Prepend default palette: Apple colors (integrate with import feature?)
-
 ### v1.1.x
 
-- ❗ <a href="https://v2.tauri.app/plugin/updater/">Add updater</a>
-- ❗ Better color wheel: Add inputs for values (hex, rgba, etc.)
 - Add ability to reorder colors
 - More color formats:
   - Common:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "t:dev": "tauri dev",
     "t:build:debug": "tauri build --debug",
-    "t:build:release": "tauri build --release"
+    "t:build:release": "tauri build"
   },
   "dependencies": {
     "@phosphor-icons/react": "^2.1.7",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "t:dev": "tauri dev",
-    "t:build": "tauri build"
+    "t:build:debug": "tauri build --debug",
+    "t:build:release": "tauri build --release"
   },
   "dependencies": {
     "@phosphor-icons/react": "^2.1.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plain-color",
   "private": false,
-  "version": "1.0.8",
+  "version": "1.0.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@phosphor-icons/react": "^2.1.7",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-clipboard-manager": "^2.0.0",
+    "@tauri-apps/plugin-deep-link": "~2",
     "@tauri-apps/plugin-dialog": "~2",
     "@tauri-apps/plugin-fs": "~2",
     "@tauri-apps/plugin-global-shortcut": "~2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react": "^18.2.0",
     "react-colorful": "^5.6.1",
     "react-dom": "^18.2.0",
+    "react-merge-refs": "^2.1.1",
     "react-router-dom": "^6.27.0",
     "rgb-hex": "^4.1.0",
     "zustand": "^5.0.1"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -18,6 +18,7 @@ dependencies = [
  "tauri-build",
  "tauri-nspanel",
  "tauri-plugin-clipboard-manager",
+ "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-global-shortcut",
@@ -25,6 +26,7 @@ dependencies = [
  "tauri-plugin-os",
  "tauri-plugin-process",
  "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
  "termcolor",
  "tokio",
 ]
@@ -134,7 +136,7 @@ dependencies = [
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
- "zbus",
+ "zbus 4.0.1",
 ]
 
 [[package]]
@@ -159,6 +161,30 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
 ]
 
 [[package]]
@@ -652,6 +678,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.15",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "const_fn"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,6 +844,12 @@ name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -1005,6 +1057,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -1575,7 +1636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc"
 dependencies = [
  "heck 0.4.1",
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 2.0.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -1702,6 +1763,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -2474,6 +2541,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2509,7 +2589,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -2794,6 +2874,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "ordered-stream"
@@ -3129,12 +3219,20 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
- "toml_datetime",
  "toml_edit 0.20.2",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+dependencies = [
+ "toml_edit 0.22.22",
 ]
 
 [[package]]
@@ -3579,7 +3677,7 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
- "windows-registry",
+ "windows-registry 0.2.0",
 ]
 
 [[package]]
@@ -3618,6 +3716,17 @@ dependencies = [
  "spin",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e310ef0e1b6eeb79169a1171daf9abcb87a2e17c03bee2c4bb100b55c75409f"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+ "trim-in-place",
 ]
 
 [[package]]
@@ -4527,6 +4636,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-deep-link"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35d51ffd286073414d26353bcfc9e83e3cd63f96fa7f7a912f92f2118e5de5a6"
+dependencies = [
+ "dunce",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.9",
+ "tracing",
+ "url",
+ "windows-registry 0.3.0",
+ "windows-result",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4651,6 +4780,21 @@ dependencies = [
  "tauri-plugin",
  "thiserror 1.0.68",
  "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c387d4d96690131dc46d1d2827df5c222b896a2bfeb15a16267229a55c50b5"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.9",
+ "tracing",
+ "windows-sys 0.59.0",
+ "zbus 5.3.0",
 ]
 
 [[package]]
@@ -4906,6 +5050,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5008,9 +5161,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
 ]
@@ -5025,7 +5178,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -5038,7 +5191,18 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap 2.6.0",
+ "toml_datetime",
+ "winnow 0.6.24",
 ]
 
 [[package]]
@@ -5098,6 +5262,12 @@ dependencies = [
  "thiserror 1.0.68",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "trim-in-place"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343e926fc669bc8cde4fa3129ab681c63671bae288b1f1081ceee6d9d37904fc"
 
 [[package]]
 name = "try-lock"
@@ -5630,7 +5800,7 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-result",
- "windows-strings",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
@@ -5663,7 +5833,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
  "windows-result",
- "windows-strings",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafa604f2104cf5ae2cc2db1dee84b7e6a5d11b05f737b60def0ffdc398cbc0a"
+dependencies = [
+ "windows-result",
+ "windows-strings 0.2.0",
  "windows-targets 0.52.6",
 ]
 
@@ -5683,6 +5864,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978d65aedf914c664c510d9de43c8fd85ca745eaff1ed53edf409b479e441663"
+dependencies = [
  "windows-targets 0.52.6",
 ]
 
@@ -5919,6 +6109,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.6.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6072,7 +6271,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "hex",
- "nix",
+ "nix 0.27.1",
  "ordered-stream",
  "rand 0.8.5",
  "serde",
@@ -6084,9 +6283,45 @@ dependencies = [
  "uds_windows",
  "windows-sys 0.52.0",
  "xdg-home",
- "zbus_macros",
- "zbus_names",
- "zvariant",
+ "zbus_macros 4.0.1",
+ "zbus_names 3.0.0",
+ "zvariant 4.0.0",
+]
+
+[[package]]
+name = "zbus"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "192a0d989036cd60a1e91a54c9851fb9ad5bd96125d41803eed79d2e2ef74bd7"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "nix 0.29.0",
+ "ordered-stream",
+ "serde",
+ "serde_repr",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.59.0",
+ "winnow 0.6.24",
+ "xdg-home",
+ "zbus_macros 5.3.0",
+ "zbus_names 4.1.1",
+ "zvariant 5.2.0",
 ]
 
 [[package]]
@@ -6100,7 +6335,22 @@ dependencies = [
  "quote",
  "regex",
  "syn 1.0.109",
- "zvariant_utils",
+ "zvariant_utils 1.1.0",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3685b5c81fce630efc3e143a4ded235b107f1b1cdf186c3f115529e5e5ae4265"
+dependencies = [
+ "proc-macro-crate 3.2.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "zbus_names 4.1.1",
+ "zvariant 5.2.0",
+ "zvariant_utils 3.1.0",
 ]
 
 [[package]]
@@ -6111,7 +6361,19 @@ checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
 dependencies = [
  "serde",
  "static_assertions",
- "zvariant",
+ "zvariant 4.0.0",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519629a3f80976d89c575895b05677cbc45eaf9f70d62a364d819ba646409cc8"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "winnow 0.6.24",
+ "zvariant 5.2.0",
 ]
 
 [[package]]
@@ -6195,7 +6457,22 @@ dependencies = [
  "serde",
  "static_assertions",
  "url",
- "zvariant_derive",
+ "zvariant_derive 4.0.0",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55e6b9b5f1361de2d5e7d9fd1ee5f6f7fcb6060618a1f82f3472f58f2b8d4be9"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "winnow 0.6.24",
+ "zvariant_derive 5.2.0",
+ "zvariant_utils 3.1.0",
 ]
 
 [[package]]
@@ -6208,7 +6485,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "zvariant_utils",
+ "zvariant_utils 1.1.0",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "573a8dd76961957108b10f7a45bac6ab1ea3e9b7fe01aff88325dc57bb8f5c8b"
+dependencies = [
+ "proc-macro-crate 3.2.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "zvariant_utils 3.1.0",
 ]
 
 [[package]]
@@ -6220,4 +6510,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd46446ea2a1f353bfda53e35f17633afa79f4fe290a611c94645c69fe96a50"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "static_assertions",
+ "syn 2.0.87",
+ "winnow 0.6.24",
 ]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "PlainColor"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "PlainColor"
-version = "1.0.8"
+version = "1.0.9"
 description = "A Tauri App"
 authors = ["Eugene Volynko <volynko.ua@gmail.com>"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,9 +36,11 @@ rcms = "0.1.0"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-http = "2"
+tauri-plugin-deep-link = "2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.26.0"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-global-shortcut = "2"
+tauri-plugin-single-instance = "2"

--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -4,5 +4,8 @@
 <dict>
     <key>com.apple.security.device.audio-video-capture</key>
     <true/>
+    <!-- Allow access to files explicitly opened by the user -->
+    <key>com.apple.security.files.user-selected.read-only</key>
+    <true/>
 </dict>
 </plist>

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>LSUIElement</key>
-    <true />
     <key>NSScreenCaptureUsageDescription</key>
     <string>This permission is required to allow the picker to capture the screen.</string>
 </dict>

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -35,6 +35,12 @@
       "identifier": "http:default",
       "allow": [
         {
+          "url": "https://api.github.com/repos/phpcolor/apple-colors/contents/Resources/colors"
+        },
+        {
+          "url": "https://raw.githubusercontent.com/phpcolor/apple-colors/main/Resources/colors/*"
+        },
+        {
           "url": "https://raw.githubusercontent.com/tailwindlabs/tailwindcss/refs/heads/main/src/public/colors.js"
         },
         {

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -17,6 +17,7 @@
     "core:window:allow-set-cursor-visible",
     "clipboard-manager:default",
     "clipboard-manager:allow-write-text",
+    "clipboard-manager:allow-read-text",
     "core:event:default",
     "core:event:allow-listen",
     "core:event:allow-emit-to",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -14,6 +14,7 @@
     "core:window:allow-minimize",
     "core:window:allow-create",
     "core:window:allow-set-position",
+    "core:window:allow-set-cursor-visible",
     "clipboard-manager:default",
     "clipboard-manager:allow-write-text",
     "core:event:default",
@@ -33,7 +34,12 @@
     {
       "identifier": "http:default",
       "allow": [
-        { "url": "https://raw.githubusercontent.com/tailwindlabs/tailwindcss/refs/heads/main/src/public/colors.js" }
+        {
+          "url": "https://raw.githubusercontent.com/tailwindlabs/tailwindcss/refs/heads/main/src/public/colors.js"
+        },
+        {
+          "url": "https://raw.githubusercontent.com/mui/material-ui/refs/heads/master/packages/mui-material/src/colors/*"
+        }
       ]
     }
   ]

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -47,6 +47,8 @@
           "url": "https://raw.githubusercontent.com/mui/material-ui/refs/heads/master/packages/mui-material/src/colors/*"
         }
       ]
-    }
+    },
+    "deep-link:default",
+    "deep-link:allow-get-current"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -64,16 +64,17 @@ pub fn run() {
         .setup(|app| {
             #[cfg(target_os = "macos")]
             {
+                use cocoa::appkit::{NSMainMenuWindowLevel, NSWindowCollectionBehavior};
                 use tauri_nspanel::WebviewWindowExt;
 
                 let picker_window = app.get_webview_window("picker").unwrap();
                 let picker_panel = picker_window.to_panel().unwrap();
-                picker_panel.set_level(cocoa::appkit::NSMainMenuWindowLevel + 1);
+                picker_panel.set_level(NSMainMenuWindowLevel + 1);
                 picker_panel.set_style_mask(NSWindowStyleMaskNonActivatingPanel);
                 picker_panel.set_collection_behaviour(
-                    cocoa::appkit::NSWindowCollectionBehavior::NSWindowCollectionBehaviorCanJoinAllSpaces
-                        | cocoa::appkit::NSWindowCollectionBehavior::NSWindowCollectionBehaviorStationary
-                        | cocoa::appkit::NSWindowCollectionBehavior::NSWindowCollectionBehaviorFullScreenAuxiliary,
+                    NSWindowCollectionBehavior::NSWindowCollectionBehaviorCanJoinAllSpaces
+                        | NSWindowCollectionBehavior::NSWindowCollectionBehaviorStationary
+                        | NSWindowCollectionBehavior::NSWindowCollectionBehaviorFullScreenAuxiliary,
                 );
             }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -94,10 +94,14 @@ pub fn run() {
         .on_window_event(|window, event| {
             if let WindowEvent::DragDrop(drag_drop_event) = event {
                 match drag_drop_event {
-                    // If the event is of type "Drop", handle the dropped file paths
                     DragDropEvent::Drop { paths, .. } => {
-                        if let Some(file) = paths.get(0) {
-                            window.emit("open_file", file.to_string_lossy()).unwrap();
+                        if let Some(files) = Some(
+                            paths
+                                .into_iter()
+                                .map(|path| path.to_string_lossy().to_string())
+                                .collect::<Vec<String>>(),
+                        ) {
+                            window.emit("trigger_deep_link", files).unwrap();
                         }
                     }
                     _ => {}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -62,6 +62,7 @@ pub fn run() {
             mod_commands::request_macos_screen_recording_permission,
             mod_commands::open_macos_screen_recording_settings,
             mod_commands::load_clr_file,
+            mod_commands::save_clr_file,
         ])
         .setup(|app| {
             #[cfg(target_os = "macos")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -54,6 +54,13 @@ pub fn run() {
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_nspanel::init())
+        .plugin(tauri_plugin_single_instance::init(|app, args, cwd| {
+            let _ = app
+                .get_webview_window("main")
+                .expect("no main window")
+                .set_focus();
+        }))
+        .plugin(tauri_plugin_deep_link::init())
         .invoke_handler(generate_handler![
             mod_commands::start_picker_loop,
             mod_commands::stop_picker_loop,
@@ -66,15 +73,6 @@ pub fn run() {
             mod_commands::save_clr_file,
         ])
         .setup(|app| {
-            let args: Vec<String> = std::env::args().collect();
-
-            if args.len() > 1 {
-                let file_path = &args[1]; // The first argument is the file path
-                if let Some(window) = app.get_webview_window("main") {
-                    window.emit("open_file", file_path).unwrap();
-                }
-            }
-
             #[cfg(target_os = "macos")]
             {
                 use cocoa::appkit::{NSMainMenuWindowLevel, NSWindowCollectionBehavior};

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod mod_clr;
 mod mod_coloradjustments;
 mod mod_commands;
 mod mod_display;
@@ -60,6 +61,7 @@ pub fn run() {
             mod_commands::check_macos_screen_recording_permission,
             mod_commands::request_macos_screen_recording_permission,
             mod_commands::open_macos_screen_recording_settings,
+            mod_commands::load_clr_file,
         ])
         .setup(|app| {
             #[cfg(target_os = "macos")]

--- a/src-tauri/src/mod_clr.rs
+++ b/src-tauri/src/mod_clr.rs
@@ -1,0 +1,69 @@
+use std::process::Command;
+
+pub fn load_clr_file_with_script() -> String {
+    // JXA script as a raw string literal
+    let jxa_script = r#"
+        var app;
+        var clrFilePath;
+        var colorList = {};
+        var jsonFilePath;
+        var nsColorList;
+        var nsStringColorList;
+        var paletteName;
+
+        function c2h(colorValue) {
+            return ('0' + Math.round(colorValue * 255).toString(16)).slice(-2);
+        }
+
+        function a2h(alphaValue) {
+            var result = c2h(alphaValue);
+            return result === 'ff' ? '' : result;
+        }
+
+        ObjC.import('AppKit');
+        app = Application.currentApplication();
+        app.includeStandardAdditions = true;
+        clrFilePath = app.chooseFile({ withPrompt: 'Import palette from Apple Color List (.clr) file', ofType: ['clr'] }).toString();
+        paletteName = clrFilePath.slice(clrFilePath.lastIndexOf('/') + 1);
+        paletteName = paletteName.slice(0, paletteName.lastIndexOf('.'));
+
+        nsColorList = $.NSColorList.alloc.initWithNameFromFile(paletteName, clrFilePath);
+        nsColorList.allKeys.js.forEach(function _getColor(colorName) {
+            var nsColor;
+            var colorValue;
+
+            nsColor = nsColorList.colorWithKey(colorName);
+            if (nsColor.colorSpaceName.js === 'NSCalibratedWhiteColorSpace') {
+                colorValue = ['#', c2h(nsColor.whiteComponent), c2h(nsColor.whiteComponent), c2h(nsColor.whiteComponent), a2h(nsColor.alphaComponent)].filter(Boolean).join('');
+            } else {
+                colorValue = ['#', c2h(nsColor.redComponent), c2h(nsColor.greenComponent), c2h(nsColor.blueComponent), a2h(nsColor.alphaComponent)].filter(Boolean).join('');
+            }
+            colorList[colorName.js] = colorValue;
+        });
+
+        JSON.stringify({ paletteName, colorList }, null, 2)
+    "#;
+
+    // Run the JXA script using osascript with the `-l JavaScript` flag
+    let output = Command::new("osascript")
+        .arg("-l")
+        .arg("JavaScript")
+        .arg("-e")
+        .arg(jxa_script)
+        .output();
+
+    // Capture the output
+    if let Ok(output) = output {
+        if output.status.success() {
+            let json_output = String::from_utf8_lossy(&output.stdout);
+            return json_output.to_string(); // Return the JSON string
+        } else {
+            return format!(
+                "Error executing JXA script: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    } else {
+        return "Failed to execute osascript".to_string(); // Return error message as string
+    }
+}

--- a/src-tauri/src/mod_commands.rs
+++ b/src-tauri/src/mod_commands.rs
@@ -38,7 +38,9 @@ pub fn set_picker_color_profile(
     _state: tauri::State<'_, Arc<tokio::sync::Mutex<mod_pickerloop::LoopState>>>,
     profile: String,
 ) {
-    mod_globalvars::set_color_profile(mod_globalvars::ColorProfile::from_str(&profile).unwrap());
+    mod_globalvars::set_screen_color_profile(
+        mod_globalvars::ScreenColorProfile::from_str(&profile).unwrap(),
+    );
 }
 
 #[tauri::command]

--- a/src-tauri/src/mod_commands.rs
+++ b/src-tauri/src/mod_commands.rs
@@ -63,3 +63,12 @@ pub fn open_macos_screen_recording_settings() {
 pub fn load_clr_file() -> String {
     return mod_clr::load_clr_file_with_script();
 }
+
+#[tauri::command]
+pub fn save_clr_file(
+    _app: tauri::AppHandle,
+    _state: tauri::State<'_, Arc<tokio::sync::Mutex<mod_pickerloop::LoopState>>>,
+    json: String,
+) -> String {
+    return mod_clr::save_clr_file_with_script(json);
+}

--- a/src-tauri/src/mod_commands.rs
+++ b/src-tauri/src/mod_commands.rs
@@ -1,3 +1,4 @@
+use crate::mod_clr;
 use crate::mod_globalvars;
 use crate::mod_macospermissions;
 use crate::mod_pickerloop;
@@ -56,4 +57,9 @@ pub fn request_macos_screen_recording_permission() -> bool {
 #[tauri::command]
 pub fn open_macos_screen_recording_settings() {
     return mod_macospermissions::open_macos_screen_recording_settings();
+}
+
+#[tauri::command]
+pub fn load_clr_file() -> String {
+    return mod_clr::load_clr_file_with_script();
 }

--- a/src-tauri/src/mod_commands.rs
+++ b/src-tauri/src/mod_commands.rs
@@ -60,8 +60,12 @@ pub fn open_macos_screen_recording_settings() {
 }
 
 #[tauri::command]
-pub fn load_clr_file() -> String {
-    return mod_clr::load_clr_file_with_script();
+pub fn load_clr_file(
+    _app: tauri::AppHandle,
+    _state: tauri::State<'_, Arc<tokio::sync::Mutex<mod_pickerloop::LoopState>>>,
+    file: String,
+) -> String {
+    return mod_clr::load_clr_file_with_script(file);
 }
 
 #[tauri::command]

--- a/src-tauri/src/mod_display.rs
+++ b/src-tauri/src/mod_display.rs
@@ -1,6 +1,4 @@
 use core_graphics::display::{CGDisplay, CGPoint};
-// use objc::runtime::{Class, Object};
-// use objc::{msg_send, sel, sel_impl};
 
 pub fn get_display_from_coordinates(x: f64, y: f64) -> Option<CGDisplay> {
     let valid_x = x.max(0 as f64);
@@ -22,26 +20,3 @@ pub fn get_display_from_coordinates(x: f64, y: f64) -> Option<CGDisplay> {
 
     None
 }
-
-// pub fn get_display_color_space(display: CGDisplay) -> Option<*mut Object> {
-//     let display_id = display.id;
-//     let nsscreen_class = Class::get("NSScreen").expect("Class not found");
-//     let screens: *mut Object = unsafe { msg_send![nsscreen_class, screens] };
-//     let count: usize = unsafe { msg_send![screens, count] };
-
-//     for i in 0..count {
-//         let screen_at_index: *mut Object = unsafe { msg_send![screens, objectAtIndex: i] };
-
-//         let screen_display_id: u32 = unsafe { msg_send![screen_at_index, deviceDescription] };
-
-//         if screen_display_id == display_id {
-//             let color_space: *mut Object = unsafe { msg_send![screen_at_index, colorSpace] };
-
-//             if !color_space.is_null() {
-//                 return Some(color_space);
-//             }
-//         }
-//     }
-
-//     None
-// }

--- a/src-tauri/src/mod_globalvars.rs
+++ b/src-tauri/src/mod_globalvars.rs
@@ -3,34 +3,34 @@ use std::sync::{Arc, Mutex};
 use std::str::FromStr;
 
 #[derive(PartialEq, Eq)]
-pub enum ColorProfile {
+pub enum ScreenColorProfile {
     SYSTEM,
     SRGB,
 }
 
-impl FromStr for ColorProfile {
+impl FromStr for ScreenColorProfile {
     type Err = ();
 
-    fn from_str(input: &str) -> Result<ColorProfile, Self::Err> {
+    fn from_str(input: &str) -> Result<ScreenColorProfile, Self::Err> {
         match input {
-            "SYSTEM" => Ok(ColorProfile::SYSTEM),
-            "SRGB" => Ok(ColorProfile::SRGB),
+            "SYSTEM" => Ok(ScreenColorProfile::SYSTEM),
+            "SRGB" => Ok(ScreenColorProfile::SRGB),
             _ => Err(()),
         }
     }
 }
 
-impl Clone for ColorProfile {
+impl Clone for ScreenColorProfile {
     fn clone(&self) -> Self {
         match self {
-            ColorProfile::SYSTEM => ColorProfile::SYSTEM,
-            ColorProfile::SRGB => ColorProfile::SRGB,
+            ScreenColorProfile::SYSTEM => ScreenColorProfile::SYSTEM,
+            ScreenColorProfile::SRGB => ScreenColorProfile::SRGB,
         }
     }
 }
 
 static mut GLOBAL_PREVIEW_SIZE: Option<Arc<Mutex<u32>>> = None;
-static mut GLOBAL_COLOR_PROFILE: Option<Arc<Mutex<ColorProfile>>> = None;
+static mut GLOBAL_COLOR_PROFILE: Option<Arc<Mutex<ScreenColorProfile>>> = None;
 
 pub fn initialize_global_vars() {
     unsafe {
@@ -39,7 +39,7 @@ pub fn initialize_global_vars() {
         }
 
         if GLOBAL_COLOR_PROFILE.is_none() {
-            GLOBAL_COLOR_PROFILE = Some(Arc::new(Mutex::new(ColorProfile::SRGB)));
+            GLOBAL_COLOR_PROFILE = Some(Arc::new(Mutex::new(ScreenColorProfile::SRGB)));
         }
     }
 }
@@ -58,14 +58,14 @@ pub fn set_preview_size(value: u32) {
     }
 }
 
-pub fn get_color_profile() -> ColorProfile {
+pub fn get_color_profile() -> ScreenColorProfile {
     unsafe {
         let color_profile = GLOBAL_COLOR_PROFILE.as_ref().unwrap().lock().unwrap();
         color_profile.clone()
     }
 }
 
-pub fn set_color_profile(value: ColorProfile) {
+pub fn set_screen_color_profile(value: ScreenColorProfile) {
     unsafe {
         let mut color_profile = GLOBAL_COLOR_PROFILE.as_ref().unwrap().lock().unwrap();
         *color_profile = value;

--- a/src-tauri/src/mod_screenshot.rs
+++ b/src-tauri/src/mod_screenshot.rs
@@ -61,7 +61,7 @@ pub fn capture_screen_area(
 
                     let color_profile = mod_globalvars::get_color_profile();
 
-                    if color_profile == mod_globalvars::ColorProfile::SRGB {
+                    if color_profile == mod_globalvars::ScreenColorProfile::SRGB {
                         let rgb = color_space_adjustment(r, g, b);
                         r = rgb.0;
                         g = rgb.1;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PlainColor",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "identifier": "com.moduleart.plaincolor",
   "build": {
     "beforeDevCommand": "yarn dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -70,8 +70,20 @@
       "entitlements": "./Entitlements.plist"
     },
     "fileAssociations": [
-      { "name": "PlainColor JSON", "description": "PlainColor JSON", "ext": ["plaincolorjson"], "role": "Viewer" },
-      { "name": "Apple Color List", "description": "Apple Color List", "ext": ["clr"], "role": "Viewer" }
+      {
+        "name": "PlainColor JSON",
+        "description": "PlainColor JSON",
+        "ext": ["plaincolorjson"],
+        "role": "Editor",
+        "mimeType": "application/json"
+      },
+      {
+        "name": "Apple Color List",
+        "description": "Apple Color List",
+        "ext": ["clr"],
+        "role": "Editor",
+        "mimeType": "application/octet-stream"
+      }
     ]
   }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -68,6 +68,10 @@
     "macOS": {
       "signingIdentity": "-",
       "entitlements": "./Entitlements.plist"
-    }
+    },
+    "fileAssociations": [
+      { "name": "PlainColor JSON", "description": "PlainColor JSON", "ext": ["plaincolorjson"], "role": "Viewer" },
+      { "name": "Apple Color List", "description": "Apple Color List", "ext": ["clr"], "role": "Viewer" }
+    ]
   }
 }

--- a/src/assets/scss/animations.scss
+++ b/src/assets/scss/animations.scss
@@ -1,4 +1,4 @@
-@keyframes keyframes_copiedOverlay {
+@keyframes keyframes_messageOverlay {
   0% {
     opacity: 0;
     transform: scale(2);

--- a/src/assets/scss/global.scss
+++ b/src/assets/scss/global.scss
@@ -18,7 +18,7 @@
   -moz-user-select: none; /* Firefox */
   -ms-user-select: none; /* Internet Explorer/Edge */
   user-select: none;
-  overscroll-behavior-y: none;
+  overscroll-behavior: none;
   cursor: default;
   outline: none;
 

--- a/src/assets/scss/global.scss
+++ b/src/assets/scss/global.scss
@@ -1,4 +1,5 @@
 @import url('./variables.scss');
+@import url('./animations.scss');
 @import url('../../lib/plainlib.scss');
 
 * {

--- a/src/assets/scss/global.scss
+++ b/src/assets/scss/global.scss
@@ -40,3 +40,7 @@ body {
   display: flex;
   flex-direction: column;
 }
+
+::selection {
+  background-color: var(--color_primary);
+}

--- a/src/assets/scss/variables.scss
+++ b/src/assets/scss/variables.scss
@@ -1,4 +1,5 @@
 :root {
+  --color_primary: #007aff;
   --color_window: #111111;
   --color_bg: #1e1e1e;
   --color_text: #ffffff;

--- a/src/components/ColorCard/index.scss
+++ b/src/components/ColorCard/index.scss
@@ -18,7 +18,7 @@
   }
 
   &__copied-overlay {
-    animation-name: keyframes_copiedOverlay;
+    animation-name: keyframes_messageOverlay;
     animation-duration: 1000ms;
     animation-fill-mode: forwards;
     position: absolute;

--- a/src/components/ColorCard/index.tsx
+++ b/src/components/ColorCard/index.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/Button'
 import { Copy, Trash, PencilSimple, PlusSquare, DotsThreeOutline, Palette } from '@phosphor-icons/react'
 import { Text } from '@/components/Text'
 import { writeText } from '@tauri-apps/plugin-clipboard-manager'
-import { hexWithoutAlpha, isDark } from '@/utils/color'
+import { generateColorLabel, hexWithoutAlpha, isDark } from '@/utils/color'
 import cn from 'classnames'
 import { useSettingsStore } from '@/store/settings.store'
 import { copyVariants, formatCopyText } from '@/utils/copyVariants.util'
@@ -46,7 +46,7 @@ export const ColorCard: FC<IColorCardProps> = ({
   }
 
   const onLabelBlur = () => {
-    onColorChange && onColorChange({ ...color, label: sanitizeLabel(color.label) })
+    onColorChange && onColorChange({ ...color, label: sanitizeLabel(color.label) || generateColorLabel(color.hex) })
   }
 
   const quickCopyVariants = copyVariants.filter((variant) => settingsStore.quickCopyVariants.includes(variant.id))

--- a/src/components/ColorCard/index.tsx
+++ b/src/components/ColorCard/index.tsx
@@ -15,7 +15,7 @@ import { commonComponentClasses } from '@/lib'
 import { IContextMenuItem, IContextMenuShowMenuProps, useContextMenuStore } from '@/store/contextMenu.store'
 import { usePalettesStore } from '@/store/palettes.store'
 import { useRightClick } from '@/hooks/useRightClick.hook'
-import { sanitizeLabel } from '@/utils/label.util'
+import { sanitizeLabel } from '@/utils/sanitize.util'
 
 export const ColorCard: FC<IColorCardProps> = ({
   color,

--- a/src/components/ColorCard/index.tsx
+++ b/src/components/ColorCard/index.tsx
@@ -15,6 +15,7 @@ import { commonComponentClasses } from '@/lib'
 import { IContextMenuItem, IContextMenuShowMenuProps, useContextMenuStore } from '@/store/contextMenu.store'
 import { usePalettesStore } from '@/store/palettes.store'
 import { useRightClick } from '@/hooks/useRightClick.hook'
+import { sanitizeLabel } from '@/utils/label.util'
 
 export const ColorCard: FC<IColorCardProps> = ({
   color,
@@ -42,6 +43,10 @@ export const ColorCard: FC<IColorCardProps> = ({
 
   const onLabelChange = (label: string) => {
     onColorChange && onColorChange({ ...color, label })
+  }
+
+  const onLabelBlur = () => {
+    onColorChange && onColorChange({ ...color, label: sanitizeLabel(color.label) })
   }
 
   const quickCopyVariants = copyVariants.filter((variant) => settingsStore.quickCopyVariants.includes(variant.id))
@@ -139,7 +144,13 @@ export const ColorCard: FC<IColorCardProps> = ({
         {variant === 'list' && (
           <>
             <Stack>
-              <Text text={color.label} grow editable={!!onColorChange} onTextChange={onLabelChange} />
+              <Text
+                text={color.label}
+                grow
+                editable={!!onColorChange}
+                onTextChange={onLabelChange}
+                onInputBlur={onLabelBlur}
+              />
               <Button
                 iconPre={DotsThreeOutline}
                 variant="clear"

--- a/src/components/ColorCard/index.tsx
+++ b/src/components/ColorCard/index.tsx
@@ -150,6 +150,8 @@ export const ColorCard: FC<IColorCardProps> = ({
                 editable={!!onColorChange}
                 onTextChange={onLabelChange}
                 onInputBlur={onLabelBlur}
+                textWrap={false}
+                maxWidth={244}
               />
               <Button
                 iconPre={DotsThreeOutline}

--- a/src/components/ColorInput/index.scss
+++ b/src/components/ColorInput/index.scss
@@ -1,0 +1,14 @@
+.color-input {
+  &__hex-input {
+    flex-basis: 32%;
+  }
+
+  input {
+    width: 100%;
+    text-align: center;
+    padding: 0.5rem 0;
+    border-radius: 0.375rem;
+    background: var(--color_element);
+    cursor: text;
+  }
+}

--- a/src/components/ColorInput/index.scss
+++ b/src/components/ColorInput/index.scss
@@ -10,5 +10,6 @@
     border-radius: 0.375rem;
     background: var(--color_element);
     cursor: text;
+    text-transform: uppercase;
   }
 }

--- a/src/components/ColorInput/index.tsx
+++ b/src/components/ColorInput/index.tsx
@@ -4,8 +4,15 @@ import { Text } from '@/components/Text'
 import { hexToRgbObj } from '@/utils/color/rgb.color.util'
 import { IColorInputProps } from './props'
 import './index.scss'
+import {
+  sanitizeHexInputValue,
+  sanitizeHexInputBlur,
+  sanitizeRgbInputValue,
+  sanitizeRgbInputBlur,
+} from '@/utils/sanitize.util'
+import { rgbToHex } from '@/utils/color'
 
-export const ColorInput: FC<IColorInputProps> = ({ colorHex }) => {
+export const ColorInput: FC<IColorInputProps> = ({ colorHex, onChange }) => {
   const [innerHex, setInnerHex] = useState('000000')
   const [innerR, setInnerR] = useState('0')
   const [innerG, setInnerG] = useState('0')
@@ -13,7 +20,7 @@ export const ColorInput: FC<IColorInputProps> = ({ colorHex }) => {
   const [innerA, setInnerA] = useState('0')
 
   useEffect(() => {
-    setInnerHex(colorHex)
+    setInnerHex(colorHex.toUpperCase())
 
     const rgb = hexToRgbObj(colorHex)
     setInnerR(rgb.red.toString())
@@ -22,56 +29,51 @@ export const ColorInput: FC<IColorInputProps> = ({ colorHex }) => {
     setInnerA(Math.trunc(rgb.alpha * 100).toString())
   }, [colorHex])
 
-  const sanitizeHexInputChange = (text: string, maxLength: 6 | 8 = 6) => {
-    // Remove invalid characters
-    const sanitized = text.replace(/[^0-9a-fA-F]/g, '').slice(0, maxLength)
-
-    // Check if the sanitized value is a valid hex color
-    const regex = maxLength === 6 ? /^[0-9a-fA-F]{1,6}$/ : /^[0-9a-fA-F]{1,8}$/
-
-    return regex.test(sanitized) ? sanitized : ''
+  const prepareNewValue = () => {
+    return rgbToHex({
+      red: Number(innerR) || 0,
+      green: Number(innerG) || 0,
+      blue: Number(innerB) || 0,
+      alpha: (Number(innerA) || 0) / 100,
+    })
   }
 
-  const sanitizeHexInputBlur = (value: string) => {
-    // Sanitize the input: Remove invalid characters and convert to lowercase
-    let sanitized = value.replace(/[^0-9a-f]/g, '').toLowerCase()
-
-    // If the input is empty, return "000000"
-    if (sanitized === '') {
-      return '000000'
-    }
-
-    // If the input length is less than 6, repeat it to fill 6 characters
-    if (sanitized.length < 6) {
-      // Repeat the input enough times to get at least 6 characters
-      return sanitized.repeat(6).slice(0, 6)
-    }
-
-    // If the input length is greater than 6, truncate it to 6 characters
-    if (sanitized.length > 6) {
-      return sanitized.slice(0, 6)
-    }
-
-    // If it's exactly 6 characters, return as-is
-    return sanitized
+  const handleInnerHexBlur = () => {
+    const newValue = sanitizeHexInputBlur(innerHex)
+    setInnerHex(newValue)
+    onChange(newValue)
   }
 
-  const sanitizeRgbInputChange = (text: string) => {
-    // Remove non-numeric characters
-    let sanitized = text.replace(/[^0-9]/g, '')
+  const handleInnerRBlur = () => {
+    const newValue = sanitizeRgbInputBlur(innerR)
+    setInnerR(newValue)
 
-    // Remove leading zeros unless the input is exactly "0"
-    sanitized = sanitized.replace(/^0+(?!$)/, '')
+    const hex = prepareNewValue()
+    onChange(hex)
+  }
 
-    // Limit the input to a maximum of 3 digits
-    sanitized = sanitized.slice(0, 3)
+  const handleInnerGBlur = () => {
+    const newValue = sanitizeRgbInputBlur(innerG)
+    setInnerG(newValue)
 
-    // Ensure the value does not exceed 255
-    if (sanitized !== '' && parseInt(sanitized, 10) > 255) {
-      return '255'
-    }
+    const hex = prepareNewValue()
+    onChange(hex)
+  }
 
-    return sanitized
+  const handleInnerBBlur = () => {
+    const newValue = sanitizeRgbInputBlur(innerB)
+    setInnerB(newValue)
+
+    const hex = prepareNewValue()
+    onChange(hex)
+  }
+
+  const handleInnerABlur = () => {
+    const newValue = sanitizeRgbInputBlur(innerA)
+    setInnerA(newValue)
+
+    const hex = prepareNewValue()
+    onChange(hex)
   }
 
   return (
@@ -80,8 +82,8 @@ export const ColorInput: FC<IColorInputProps> = ({ colorHex }) => {
         <Text text="HEX" size="small" tinted />
         <input
           value={innerHex}
-          onChange={(e) => setInnerHex(sanitizeHexInputChange(e.target.value))}
-          onBlur={(e) => setInnerHex(sanitizeHexInputBlur(e.target.value))}
+          onChange={(e) => setInnerHex(sanitizeHexInputValue(e.target.value))}
+          onBlur={handleInnerHexBlur}
           autoComplete="off"
           autoCorrect="off"
           autoCapitalize="off"
@@ -92,8 +94,8 @@ export const ColorInput: FC<IColorInputProps> = ({ colorHex }) => {
           <Text text="R" size="small" tinted />
           <input
             value={innerR}
-            onChange={(e) => setInnerR(sanitizeRgbInputChange(e.target.value))}
-            onBlur={() => innerR === '' && setInnerR('0')}
+            onChange={(e) => setInnerR(sanitizeRgbInputValue(e.target.value))}
+            onBlur={handleInnerRBlur}
             autoComplete="off"
             autoCorrect="off"
             autoCapitalize="off"
@@ -103,8 +105,8 @@ export const ColorInput: FC<IColorInputProps> = ({ colorHex }) => {
           <Text text="G" size="small" tinted />
           <input
             value={innerG}
-            onChange={(e) => setInnerG(sanitizeRgbInputChange(e.target.value))}
-            onBlur={() => innerG === '' && setInnerG('0')}
+            onChange={(e) => setInnerG(sanitizeRgbInputValue(e.target.value))}
+            onBlur={handleInnerGBlur}
             autoComplete="off"
             autoCorrect="off"
             autoCapitalize="off"
@@ -114,8 +116,8 @@ export const ColorInput: FC<IColorInputProps> = ({ colorHex }) => {
           <Text text="B" size="small" tinted />
           <input
             value={innerB}
-            onChange={(e) => setInnerB(sanitizeRgbInputChange(e.target.value))}
-            onBlur={() => innerB === '' && setInnerB('0')}
+            onChange={(e) => setInnerB(sanitizeRgbInputValue(e.target.value))}
+            onBlur={handleInnerBBlur}
             autoComplete="off"
             autoCorrect="off"
             autoCapitalize="off"
@@ -125,8 +127,8 @@ export const ColorInput: FC<IColorInputProps> = ({ colorHex }) => {
           <Text text="Alpha" size="small" tinted />
           <input
             value={innerA}
-            onChange={(e) => setInnerA(sanitizeRgbInputChange(e.target.value))}
-            onBlur={() => innerA === '' && setInnerA('0')}
+            onChange={(e) => setInnerA(sanitizeRgbInputValue(e.target.value, 100))}
+            onBlur={handleInnerABlur}
             autoComplete="off"
             autoCorrect="off"
             autoCapitalize="off"

--- a/src/components/ColorInput/index.tsx
+++ b/src/components/ColorInput/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from 'react'
+import { FC, KeyboardEvent, useEffect, useState } from 'react'
 import { Stack } from '@/components/Stack'
 import { Text } from '@/components/Text'
 import { hexToRgbObj } from '@/utils/color/rgb.color.util'
@@ -76,6 +76,15 @@ export const ColorInput: FC<IColorInputProps> = ({ colorHex, onChange }) => {
     onChange(hex)
   }
 
+  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>, onBlur: () => void) => {
+    if (e.key === 'Enter') {
+      onBlur()
+    } else if (e.key === 'Escape') {
+      const input = e.target as HTMLInputElement
+      input.blur()
+    }
+  }
+
   return (
     <Stack justify="between" className="color-input">
       <Stack dir="vertical" align="center" className="color-input__hex-input">
@@ -87,6 +96,7 @@ export const ColorInput: FC<IColorInputProps> = ({ colorHex, onChange }) => {
           autoComplete="off"
           autoCorrect="off"
           autoCapitalize="off"
+          onKeyDown={(e) => onKeyDown(e, handleInnerHexBlur)}
         />
       </Stack>
       <Stack className="color-input__rgb-inputs" grow>
@@ -99,6 +109,7 @@ export const ColorInput: FC<IColorInputProps> = ({ colorHex, onChange }) => {
             autoComplete="off"
             autoCorrect="off"
             autoCapitalize="off"
+            onKeyDown={(e) => onKeyDown(e, handleInnerRBlur)}
           />
         </Stack>
         <Stack dir="vertical" align="center" grow>
@@ -110,6 +121,7 @@ export const ColorInput: FC<IColorInputProps> = ({ colorHex, onChange }) => {
             autoComplete="off"
             autoCorrect="off"
             autoCapitalize="off"
+            onKeyDown={(e) => onKeyDown(e, handleInnerGBlur)}
           />
         </Stack>
         <Stack dir="vertical" align="center" grow>
@@ -121,6 +133,7 @@ export const ColorInput: FC<IColorInputProps> = ({ colorHex, onChange }) => {
             autoComplete="off"
             autoCorrect="off"
             autoCapitalize="off"
+            onKeyDown={(e) => onKeyDown(e, handleInnerBBlur)}
           />
         </Stack>
         <Stack dir="vertical" align="center" grow>
@@ -132,6 +145,7 @@ export const ColorInput: FC<IColorInputProps> = ({ colorHex, onChange }) => {
             autoComplete="off"
             autoCorrect="off"
             autoCapitalize="off"
+            onKeyDown={(e) => onKeyDown(e, handleInnerABlur)}
           />
         </Stack>
       </Stack>

--- a/src/components/ColorInput/index.tsx
+++ b/src/components/ColorInput/index.tsx
@@ -11,6 +11,7 @@ import {
   sanitizeRgbInputBlur,
 } from '@/utils/sanitize.util'
 import { rgbToHex } from '@/utils/color'
+import { Input } from '@/components/Input'
 
 export const ColorInput: FC<IColorInputProps> = ({ colorHex, onChange }) => {
   const [innerHex, setInnerHex] = useState('000000')
@@ -89,9 +90,9 @@ export const ColorInput: FC<IColorInputProps> = ({ colorHex, onChange }) => {
     <Stack justify="between" className="color-input">
       <Stack dir="vertical" align="center" className="color-input__hex-input">
         <Text text="HEX" size="small" tinted />
-        <input
+        <Input
           value={innerHex}
-          onChange={(e) => setInnerHex(sanitizeHexInputValue(e.target.value))}
+          onChange={(value) => setInnerHex(sanitizeHexInputValue(value))}
           onBlur={handleInnerHexBlur}
           autoComplete="off"
           autoCorrect="off"
@@ -102,9 +103,9 @@ export const ColorInput: FC<IColorInputProps> = ({ colorHex, onChange }) => {
       <Stack className="color-input__rgb-inputs" grow>
         <Stack dir="vertical" align="center" grow>
           <Text text="R" size="small" tinted />
-          <input
+          <Input
             value={innerR}
-            onChange={(e) => setInnerR(sanitizeRgbInputValue(e.target.value))}
+            onChange={(value) => setInnerR(sanitizeRgbInputValue(value))}
             onBlur={handleInnerRBlur}
             autoComplete="off"
             autoCorrect="off"
@@ -114,9 +115,9 @@ export const ColorInput: FC<IColorInputProps> = ({ colorHex, onChange }) => {
         </Stack>
         <Stack dir="vertical" align="center" grow>
           <Text text="G" size="small" tinted />
-          <input
+          <Input
             value={innerG}
-            onChange={(e) => setInnerG(sanitizeRgbInputValue(e.target.value))}
+            onChange={(value) => setInnerG(sanitizeRgbInputValue(value))}
             onBlur={handleInnerGBlur}
             autoComplete="off"
             autoCorrect="off"
@@ -126,9 +127,9 @@ export const ColorInput: FC<IColorInputProps> = ({ colorHex, onChange }) => {
         </Stack>
         <Stack dir="vertical" align="center" grow>
           <Text text="B" size="small" tinted />
-          <input
+          <Input
             value={innerB}
-            onChange={(e) => setInnerB(sanitizeRgbInputValue(e.target.value))}
+            onChange={(value) => setInnerB(sanitizeRgbInputValue(value))}
             onBlur={handleInnerBBlur}
             autoComplete="off"
             autoCorrect="off"
@@ -138,9 +139,9 @@ export const ColorInput: FC<IColorInputProps> = ({ colorHex, onChange }) => {
         </Stack>
         <Stack dir="vertical" align="center" grow>
           <Text text="Alpha" size="small" tinted />
-          <input
+          <Input
             value={innerA}
-            onChange={(e) => setInnerA(sanitizeRgbInputValue(e.target.value, 100))}
+            onChange={(value) => setInnerA(sanitizeRgbInputValue(value, 100))}
             onBlur={handleInnerABlur}
             autoComplete="off"
             autoCorrect="off"

--- a/src/components/ColorInput/index.tsx
+++ b/src/components/ColorInput/index.tsx
@@ -20,7 +20,7 @@ export const ColorInput: FC<IColorInputProps> = ({ colorHex, onChange }) => {
   const [innerA, setInnerA] = useState('0')
 
   useEffect(() => {
-    setInnerHex(colorHex.toUpperCase())
+    setInnerHex(colorHex)
 
     const rgb = hexToRgbObj(colorHex)
     setInnerR(rgb.red.toString())

--- a/src/components/ColorInput/index.tsx
+++ b/src/components/ColorInput/index.tsx
@@ -1,0 +1,138 @@
+import { FC, useEffect, useState } from 'react'
+import { Stack } from '@/components/Stack'
+import { Text } from '@/components/Text'
+import { hexToRgbObj } from '@/utils/color/rgb.color.util'
+import { IColorInputProps } from './props'
+import './index.scss'
+
+export const ColorInput: FC<IColorInputProps> = ({ colorHex }) => {
+  const [innerHex, setInnerHex] = useState('000000')
+  const [innerR, setInnerR] = useState('0')
+  const [innerG, setInnerG] = useState('0')
+  const [innerB, setInnerB] = useState('0')
+  const [innerA, setInnerA] = useState('0')
+
+  useEffect(() => {
+    setInnerHex(colorHex)
+
+    const rgb = hexToRgbObj(colorHex)
+    setInnerR(rgb.red.toString())
+    setInnerG(rgb.green.toString())
+    setInnerB(rgb.blue.toString())
+    setInnerA(Math.trunc(rgb.alpha * 100).toString())
+  }, [colorHex])
+
+  const sanitizeHexInputChange = (text: string, maxLength: 6 | 8 = 6) => {
+    // Remove invalid characters
+    const sanitized = text.replace(/[^0-9a-fA-F]/g, '').slice(0, maxLength)
+
+    // Check if the sanitized value is a valid hex color
+    const regex = maxLength === 6 ? /^[0-9a-fA-F]{1,6}$/ : /^[0-9a-fA-F]{1,8}$/
+
+    return regex.test(sanitized) ? sanitized : ''
+  }
+
+  const sanitizeHexInputBlur = (value: string) => {
+    // Sanitize the input: Remove invalid characters and convert to lowercase
+    let sanitized = value.replace(/[^0-9a-f]/g, '').toLowerCase()
+
+    // If the input is empty, return "000000"
+    if (sanitized === '') {
+      return '000000'
+    }
+
+    // If the input length is less than 6, repeat it to fill 6 characters
+    if (sanitized.length < 6) {
+      // Repeat the input enough times to get at least 6 characters
+      return sanitized.repeat(6).slice(0, 6)
+    }
+
+    // If the input length is greater than 6, truncate it to 6 characters
+    if (sanitized.length > 6) {
+      return sanitized.slice(0, 6)
+    }
+
+    // If it's exactly 6 characters, return as-is
+    return sanitized
+  }
+
+  const sanitizeRgbInputChange = (text: string) => {
+    // Remove non-numeric characters
+    let sanitized = text.replace(/[^0-9]/g, '')
+
+    // Remove leading zeros unless the input is exactly "0"
+    sanitized = sanitized.replace(/^0+(?!$)/, '')
+
+    // Limit the input to a maximum of 3 digits
+    sanitized = sanitized.slice(0, 3)
+
+    // Ensure the value does not exceed 255
+    if (sanitized !== '' && parseInt(sanitized, 10) > 255) {
+      return '255'
+    }
+
+    return sanitized
+  }
+
+  return (
+    <Stack justify="between" className="color-input">
+      <Stack dir="vertical" align="center" className="color-input__hex-input">
+        <Text text="HEX" size="small" tinted />
+        <input
+          value={innerHex}
+          onChange={(e) => setInnerHex(sanitizeHexInputChange(e.target.value))}
+          onBlur={(e) => setInnerHex(sanitizeHexInputBlur(e.target.value))}
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+        />
+      </Stack>
+      <Stack className="color-input__rgb-inputs" grow>
+        <Stack dir="vertical" align="center" grow>
+          <Text text="R" size="small" tinted />
+          <input
+            value={innerR}
+            onChange={(e) => setInnerR(sanitizeRgbInputChange(e.target.value))}
+            onBlur={() => innerR === '' && setInnerR('0')}
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+          />
+        </Stack>
+        <Stack dir="vertical" align="center" grow>
+          <Text text="G" size="small" tinted />
+          <input
+            value={innerG}
+            onChange={(e) => setInnerG(sanitizeRgbInputChange(e.target.value))}
+            onBlur={() => innerG === '' && setInnerG('0')}
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+          />
+        </Stack>
+        <Stack dir="vertical" align="center" grow>
+          <Text text="B" size="small" tinted />
+          <input
+            value={innerB}
+            onChange={(e) => setInnerB(sanitizeRgbInputChange(e.target.value))}
+            onBlur={() => innerB === '' && setInnerB('0')}
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+          />
+        </Stack>
+        <Stack dir="vertical" align="center" grow>
+          <Text text="Alpha" size="small" tinted />
+          <input
+            value={innerA}
+            onChange={(e) => setInnerA(sanitizeRgbInputChange(e.target.value))}
+            onBlur={() => innerA === '' && setInnerA('0')}
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+          />
+        </Stack>
+      </Stack>
+    </Stack>
+  )
+}

--- a/src/components/ColorInput/props.ts
+++ b/src/components/ColorInput/props.ts
@@ -1,3 +1,4 @@
 export interface IColorInputProps {
   colorHex: string
+  onChange: (colorHex: string) => void
 }

--- a/src/components/ColorInput/props.ts
+++ b/src/components/ColorInput/props.ts
@@ -1,0 +1,3 @@
+export interface IColorInputProps {
+  colorHex: string
+}

--- a/src/components/ColorPicker/index.scss
+++ b/src/components/ColorPicker/index.scss
@@ -1,4 +1,6 @@
 .color-picker {
+  min-height: 140px;
+
   &.react-colorful {
     width: auto;
   }

--- a/src/components/ContextMenu/index.scss
+++ b/src/components/ContextMenu/index.scss
@@ -3,7 +3,7 @@
   background: var(--color_window);
   border-radius: 0.375rem;
   width: 200px;
-  max-height: calc(100% - 200px);
+  max-height: 196px;
   overflow-y: auto;
   z-index: 5;
 }

--- a/src/components/ContextMenu/index.scss
+++ b/src/components/ContextMenu/index.scss
@@ -6,4 +6,5 @@
   max-height: 196px;
   overflow-y: auto;
   z-index: 5;
+  pointer-events: none;
 }

--- a/src/components/ContextMenu/index.tsx
+++ b/src/components/ContextMenu/index.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, useEffect, useMemo } from 'react'
 import { Stack } from '@/components/Stack'
 import { Button } from '@/components/Button'
 import { IContextMenuItem, useContextMenuStore } from '@/store/contextMenu.store'
@@ -23,12 +23,33 @@ export const ContextMenu: FC = () => {
     menuItem.onClick && menuItem.onClick(event)
   }
 
-  const posX = Math.min(contextMenuStore.position.x, window.innerWidth - 208)
-  const posY = Math.min(
-    contextMenuStore.position.y,
-    window.innerHeight -
-      (contextMenuStore.menuItems.length > 7 ? 288 : contextMenuStore.menuItems.reduce((prev) => prev + 36, 24))
+  const posX = useMemo(
+    () => Math.min(contextMenuStore.position.x, window.innerWidth - 208),
+    [contextMenuStore.position.x]
   )
+  const posY = useMemo(
+    () =>
+      Math.min(
+        contextMenuStore.position.y,
+        window.innerHeight -
+          (contextMenuStore.menuItems.length > 5 ? 196 + 8 : contextMenuStore.menuItems.length * 36 + 16 + 8)
+      ),
+    [contextMenuStore.position.y, contextMenuStore.menuItems]
+  )
+
+  const onWindowResize = () => {
+    if (contextMenuStore.menuItems.length > 0) {
+      contextMenuStore.hideMenu()
+    }
+  }
+
+  useEffect(() => {
+    window.addEventListener('resize', onWindowResize)
+
+    return () => {
+      window.removeEventListener('resize', onWindowResize)
+    }
+  }, [])
 
   if (contextMenuStore.menuItems.length === 0) return null
 

--- a/src/components/ContextMenu/index.tsx
+++ b/src/components/ContextMenu/index.tsx
@@ -71,6 +71,7 @@ export const ContextMenu: FC = () => {
               iconPost={menuItem.subMenuItems ? CaretRight : undefined}
               tintedIconPost
               growLabel
+              pointerEvents="enable"
             />
           </Stack>
         ))}

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -1,0 +1,30 @@
+import { FC } from 'react'
+import { IInputProps } from './props'
+import cn from 'classnames'
+import { commonComponentClasses } from '@/lib'
+
+export const Input: FC<IInputProps> = ({
+  value,
+  onChange,
+  onBlur,
+  autoComplete,
+  autoCapitalize,
+  autoCorrect,
+  onKeyDown,
+  inputRef,
+  ...props
+}) => {
+  return (
+    <input
+      ref={inputRef}
+      value={value}
+      onChange={(e) => onChange && onChange(e.target.value)}
+      onBlur={onBlur}
+      autoComplete={autoComplete}
+      autoCapitalize={autoCapitalize}
+      autoCorrect={autoCorrect}
+      onKeyDown={onKeyDown}
+      className={cn('input', commonComponentClasses(props))}
+    />
+  )
+}

--- a/src/components/Input/props.ts
+++ b/src/components/Input/props.ts
@@ -1,0 +1,13 @@
+import { IPlainlibComponentProps } from '@/lib/types'
+import { KeyboardEvent, RefObject } from 'react'
+
+export interface IInputProps extends IPlainlibComponentProps {
+  value?: string
+  onChange?: (value: string) => void
+  onBlur?: () => void
+  autoComplete?: 'off'
+  autoCorrect?: 'off'
+  autoCapitalize?: 'off'
+  onKeyDown?: (event: KeyboardEvent<HTMLInputElement>) => void
+  inputRef?: RefObject<HTMLInputElement>
+}

--- a/src/components/PaletteCard/index.scss
+++ b/src/components/PaletteCard/index.scss
@@ -29,7 +29,7 @@
   }
 
   &__copied-overlay {
-    animation-name: keyframes_copiedOverlay;
+    animation-name: keyframes_messageOverlay;
     animation-duration: 1000ms;
     animation-fill-mode: forwards;
     position: absolute;

--- a/src/components/PaletteCard/index.tsx
+++ b/src/components/PaletteCard/index.tsx
@@ -37,7 +37,7 @@ export const PaletteCard: FC<IPaletteCardProps> = ({ palette, onDelete, onDuplic
       palette.colors
         .map((color) => color.hex)
         .filter((value, index, array) => array.indexOf(value) === index)
-        .slice(0, 32),
+        .slice(0, 24),
     [palette.colors]
   )
 

--- a/src/components/PickerPreview/index.scss
+++ b/src/components/PickerPreview/index.scss
@@ -6,6 +6,10 @@
   height: 100%;
   cursor: none;
 
+  * {
+    pointer-events: none;
+  }
+
   &--show-cursor {
     cursor: default;
   }
@@ -43,14 +47,12 @@
     height: var(--pixel);
     border: var(--size_borderWidth) solid var(--color_text);
     display: block;
-    pointer-events: none;
     mix-blend-mode: difference;
   }
 
   &__guideline {
     border: var(--size_borderWidth) solid var(--color_text);
     position: fixed;
-    pointer-events: none;
     mix-blend-mode: difference;
 
     &--horizontal {

--- a/src/components/PickerPreview/index.tsx
+++ b/src/components/PickerPreview/index.tsx
@@ -1,6 +1,6 @@
-import { FC, useRef, useState } from 'react'
+import { forwardRef, useImperativeHandle, useRef } from 'react'
 import './index.scss'
-import { IPickerPreviewProps } from './props'
+import { IPickerPreviewProps, IPickerPreviewRef } from './props'
 import { isDark } from '@/utils/color'
 import { Text } from '@/components/Text'
 import cn from 'classnames'
@@ -8,50 +8,48 @@ import { Stack } from '@/components/Stack'
 import { Image } from '@/components/Image'
 import { usePinchGesture } from '@/hooks/usePinchGesture.hook'
 
-export const PickerPreview: FC<IPickerPreviewProps> = ({
-  colorHex,
-  onClick,
-  previewSize,
-  image,
-  showGuidelines = false,
-  onZoomIn,
-  onZoomOut,
-}) => {
-  const [isPicked, setIsPicked] = useState(false)
-  const ref = useRef<HTMLDivElement>(null)
+export const PickerPreview = forwardRef<IPickerPreviewRef, IPickerPreviewProps>(
+  ({ colorHex, onClick, previewSize, image, showGuidelines = false, onZoomIn, onZoomOut }, ref) => {
+    const isCursorVisible = useRef(false)
 
-  usePinchGesture({ onZoomIn, onZoomOut })
+    const showCursor = () => {
+      isCursorVisible.current = true
 
-  return (
-    <div
-      ref={ref}
-      className={cn('picker-preview', {
-        'picker-preview--show-cursor': isPicked,
-        'picker-preview--invert-colors': !isDark(colorHex),
-      })}
-      onClick={() => {
-        setIsPicked(true)
-        onClick()
-        setTimeout(() => setIsPicked(false), 100)
-      }}
-      style={{ '--pixel': `calc(100% / ${previewSize - 1})` } as React.CSSProperties}
-    >
-      <Image src={image} className="picker-preview__image" pointerEvents="disable" />
-      <Stack
-        className="picker-preview__color"
-        style={{ background: `#${colorHex}` }}
-        justify="center"
-        pointerEvents="disable"
+      setTimeout(() => {
+        isCursorVisible.current = false
+      }, 100)
+    }
+
+    useImperativeHandle(ref, () => ({
+      showCursor,
+    }))
+
+    usePinchGesture({ onZoomIn, onZoomOut })
+
+    return (
+      <div
+        className={cn('picker-preview', {
+          'picker-preview--show-cursor': isCursorVisible.current,
+          'picker-preview--invert-colors': !isDark(colorHex),
+        })}
+        onClick={() => {
+          showCursor()
+          onClick()
+        }}
+        style={{ '--pixel': `calc(100% / ${previewSize - 1})` } as React.CSSProperties}
       >
-        <Text text={colorHex} tinted transform="uppercase" className="picker-preview__color-text" />
-      </Stack>
-      <div className="picker-preview__pointer"></div>
-      {showGuidelines && (
-        <>
-          <div className="picker-preview__guideline picker-preview__guideline--horizontal"></div>
-          <div className="picker-preview__guideline picker-preview__guideline--vertical"></div>
-        </>
-      )}
-    </div>
-  )
-}
+        <Image src={image} className="picker-preview__image" />
+        <Stack className="picker-preview__color" style={{ background: `#${colorHex}` }} justify="center">
+          <Text text={colorHex} tinted transform="uppercase" className="picker-preview__color-text" />
+        </Stack>
+        <div className="picker-preview__pointer"></div>
+        {showGuidelines && (
+          <>
+            <div className="picker-preview__guideline picker-preview__guideline--horizontal"></div>
+            <div className="picker-preview__guideline picker-preview__guideline--vertical"></div>
+          </>
+        )}
+      </div>
+    )
+  }
+)

--- a/src/components/PickerPreview/index.tsx
+++ b/src/components/PickerPreview/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react'
+import { FC, useRef, useState } from 'react'
 import './index.scss'
 import { IPickerPreviewProps } from './props'
 import { isDark } from '@/utils/color'
@@ -6,6 +6,7 @@ import { Text } from '@/components/Text'
 import cn from 'classnames'
 import { Stack } from '@/components/Stack'
 import { Image } from '@/components/Image'
+import { usePinchGesture } from '@/hooks/usePinchGesture.hook'
 
 export const PickerPreview: FC<IPickerPreviewProps> = ({
   colorHex,
@@ -13,11 +14,17 @@ export const PickerPreview: FC<IPickerPreviewProps> = ({
   previewSize,
   image,
   showGuidelines = false,
+  onZoomIn,
+  onZoomOut,
 }) => {
   const [isPicked, setIsPicked] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  usePinchGesture({ onZoomIn, onZoomOut })
 
   return (
     <div
+      ref={ref}
       className={cn('picker-preview', {
         'picker-preview--show-cursor': isPicked,
         'picker-preview--invert-colors': !isDark(colorHex),

--- a/src/components/PickerPreview/props.ts
+++ b/src/components/PickerPreview/props.ts
@@ -7,3 +7,7 @@ export interface IPickerPreviewProps {
   onZoomIn?: () => void
   onZoomOut?: () => void
 }
+
+export interface IPickerPreviewRef {
+  showCursor: () => void
+}

--- a/src/components/PickerPreview/props.ts
+++ b/src/components/PickerPreview/props.ts
@@ -4,4 +4,6 @@ export interface IPickerPreviewProps {
   previewSize: number
   image: string
   showGuidelines?: boolean
+  onZoomIn?: () => void
+  onZoomOut?: () => void
 }

--- a/src/components/Scroller/index.tsx
+++ b/src/components/Scroller/index.tsx
@@ -4,6 +4,7 @@ import { IScrollerProps } from './props'
 import cn from 'classnames'
 import { commonComponentClasses } from '@/lib'
 import { Stack } from '@/components/Stack'
+import { useContextMenuStore } from '@/store/contextMenu.store'
 
 export const Scroller: FC<PropsWithChildren<IScrollerProps>> = ({
   children,
@@ -11,6 +12,14 @@ export const Scroller: FC<PropsWithChildren<IScrollerProps>> = ({
   extraPaddingBottom = false,
   ...props
 }) => {
+  const contextMenuStore = useContextMenuStore()
+
+  const onScroll = () => {
+    if (contextMenuStore.menuItems.length > 0) {
+      contextMenuStore.hideMenu()
+    }
+  }
+
   return (
     <div
       className={cn(
@@ -18,6 +27,7 @@ export const Scroller: FC<PropsWithChildren<IScrollerProps>> = ({
         { 'scroller--extra-padding-top': extraPaddingTop, 'scroller--extra-padding-bottom': extraPaddingBottom },
         commonComponentClasses(props)
       )}
+      onScroll={onScroll}
     >
       <Stack dir="vertical" gap="none" grow>
         {children}

--- a/src/components/Text/index.scss
+++ b/src/components/Text/index.scss
@@ -59,4 +59,10 @@
       }
     }
   }
+
+  &--no-text-wrap &__label {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
 }

--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -1,8 +1,9 @@
-import { ChangeEvent, FC, KeyboardEvent, useRef, useState } from 'react'
+import { FC, KeyboardEvent, useRef, useState } from 'react'
 import cn from 'classnames'
 import { ITextProps } from './props'
 import './index.scss'
 import { commonComponentClasses } from '@/lib'
+import { Input } from '@/components/Input'
 
 export const Text: FC<ITextProps> = ({
   tinted = false,
@@ -26,10 +27,6 @@ export const Text: FC<ITextProps> = ({
   const onClick = () => {
     setIsEditing(true)
     setTimeout(() => inputRef.current?.focus())
-  }
-
-  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
-    onTextChange && onTextChange(e.target.value)
   }
 
   const onBlur = () => {
@@ -56,11 +53,11 @@ export const Text: FC<ITextProps> = ({
       )}
     >
       {isEditing ? (
-        <input
-          ref={inputRef}
+        <Input
+          inputRef={inputRef}
           className={cn('text__input', inputClassName)}
           value={text}
-          onChange={onChange}
+          onChange={(value) => onTextChange && onTextChange(value)}
           onBlur={onBlur}
           onKeyDown={onKeyDown}
         />

--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -10,6 +10,7 @@ export const Text: FC<ITextProps> = ({
   transform = 'none',
   editable = false,
   onTextChange,
+  onInputBlur,
   size = 'regular',
   align = 'left',
   textRef,
@@ -29,6 +30,7 @@ export const Text: FC<ITextProps> = ({
 
   const onBlur = () => {
     setIsEditing(false)
+    onInputBlur && onInputBlur()
   }
 
   const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {

--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -14,6 +14,10 @@ export const Text: FC<ITextProps> = ({
   size = 'regular',
   align = 'left',
   textRef,
+  labelClassName,
+  inputClassName,
+  maxWidth = 0,
+  textWrap = true,
   ...props
 }) => {
   const [isEditing, setIsEditing] = useState(false)
@@ -47,25 +51,31 @@ export const Text: FC<ITextProps> = ({
         [`text--align-${align}`],
         [`text--transform-${transform}`],
         [`text--size-${size}`],
-        { 'text--tinted': tinted },
+        { 'text--tinted': tinted, 'text--no-text-wrap': !textWrap },
         commonComponentClasses(props)
       )}
     >
       {isEditing ? (
         <input
           ref={inputRef}
-          className="text__input"
+          className={cn('text__input', inputClassName)}
           value={text}
           onChange={onChange}
           onBlur={onBlur}
           onKeyDown={onKeyDown}
         />
       ) : editable ? (
-        <button onClick={onClick} className="text__label text__label--clickable">
+        <button
+          onClick={onClick}
+          className={cn('text__label text__label--clickable', labelClassName)}
+          style={{ maxWidth: maxWidth ? `${maxWidth}px` : '100%' }}
+        >
           {text}
         </button>
       ) : (
-        <span className="text__label">{text}</span>
+        <span className={cn('text__label', labelClassName)} style={{ maxWidth: maxWidth ? `${maxWidth}px` : '100%' }}>
+          {text}
+        </span>
       )}
     </span>
   )

--- a/src/components/Text/props.ts
+++ b/src/components/Text/props.ts
@@ -7,6 +7,7 @@ export interface ITextProps extends IPlainlibComponentProps {
   transform?: 'none' | 'uppercase' | 'lowercase'
   editable?: boolean
   onTextChange?: (text: string) => void
+  onInputBlur?: () => void
   size?: 'regular' | 'small'
   textRef?: RefObject<HTMLSpanElement>
   align?: 'left' | 'center' | 'right'

--- a/src/components/Text/props.ts
+++ b/src/components/Text/props.ts
@@ -11,4 +11,8 @@ export interface ITextProps extends IPlainlibComponentProps {
   size?: 'regular' | 'small'
   textRef?: RefObject<HTMLSpanElement>
   align?: 'left' | 'center' | 'right'
+  labelClassName?: string
+  inputClassName?: string
+  maxWidth?: number
+  textWrap?: boolean
 }

--- a/src/components/Textarea/index.scss
+++ b/src/components/Textarea/index.scss
@@ -14,7 +14,7 @@
   }
 
   &__overlay {
-    animation-name: keyframes_copiedOverlay;
+    animation-name: keyframes_messageOverlay;
     animation-duration: 1000ms;
     animation-fill-mode: forwards;
     position: absolute;

--- a/src/components/Textarea/index.scss
+++ b/src/components/Textarea/index.scss
@@ -1,7 +1,29 @@
 .textarea {
-  resize: none;
   height: 100%;
-  font-size: 12px;
-  opacity: var(--opacity_tinted);
-  outline: none;
+  position: relative;
+  border-radius: 0.375rem;
+  overflow: hidden;
+
+  &__textarea {
+    resize: none;
+    height: 100%;
+    width: 100%;
+    font-size: 12px;
+    opacity: var(--opacity_tinted);
+    outline: none;
+  }
+
+  &__overlay {
+    animation-name: keyframes_copiedOverlay;
+    animation-duration: 1000ms;
+    animation-fill-mode: forwards;
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1;
+    margin: 0;
+    background-color: var(--color_element);
+  }
 }

--- a/src/components/Textarea/index.tsx
+++ b/src/components/Textarea/index.tsx
@@ -1,7 +1,31 @@
-import { FC } from 'react'
-import { ITextareaProps } from './props'
+import { forwardRef, useImperativeHandle, useState } from 'react'
+import { ITextareaProps, ITextareaRef } from './props'
 import './index.scss'
+import { Stack } from '@/components/Stack'
+import { Text } from '@/components/Text'
 
-export const Textarea: FC<ITextareaProps> = ({ value, readonly = false }) => {
-  return <textarea tabIndex={-1} className="textarea" value={value} readOnly={readonly} />
-}
+export const Textarea = forwardRef<ITextareaRef, ITextareaProps>(({ value, readonly = false }, ref) => {
+  const [overlayMessage, setOverlayMessage] = useState('')
+
+  useImperativeHandle(ref, () => ({
+    showOverlayMessage: (message) => {
+      if (!overlayMessage) {
+        setOverlayMessage(message)
+        setTimeout(() => setOverlayMessage(''), 1000)
+      }
+    },
+  }))
+
+  return (
+    <div className="textarea">
+      {overlayMessage && (
+        <Stack className="textarea__overlay">
+          <Stack padding="medium" grow justify="center" align="center" dir="vertical">
+            <Text align="center" text={overlayMessage} />
+          </Stack>
+        </Stack>
+      )}
+      <textarea tabIndex={-1} className="textarea__textarea" value={value} readOnly={readonly} />
+    </div>
+  )
+})

--- a/src/components/Textarea/props.ts
+++ b/src/components/Textarea/props.ts
@@ -2,3 +2,7 @@ export interface ITextareaProps {
   value: string
   readonly?: boolean
 }
+
+export interface ITextareaRef {
+  showOverlayMessage: (message: string) => void
+}

--- a/src/hooks/usePinchGesture.hook.ts
+++ b/src/hooks/usePinchGesture.hook.ts
@@ -1,0 +1,67 @@
+import { useEffect, useRef } from 'react'
+
+// Declare GestureEvent interface if needed
+interface GestureEvent extends UIEvent {
+  readonly scale: number
+  readonly rotation: number
+}
+
+export const usePinchGesture = (
+  callbacks: { onZoomIn?: () => void; onZoomOut?: () => void },
+  sensitivity = 1 // Sensitivity factor: lower = more sensitive
+) => {
+  const lastScale = useRef(1) // Tracks the previous scale for gesture events
+  const wheelAccumulator = useRef(0) // Tracks accumulated delta for wheel events
+
+  useEffect(() => {
+    const handleWheel = (event: WheelEvent) => {
+      if (event.ctrlKey) {
+        event.preventDefault()
+
+        // Scale `deltaY` by sensitivity: higher sensitivity reduces `deltaY`'s impact
+        const scaledDelta = event.deltaY * (1 / sensitivity)
+
+        wheelAccumulator.current += scaledDelta
+
+        // Trigger zoom based on accumulated value
+        if (wheelAccumulator.current <= -10) {
+          callbacks.onZoomIn && callbacks.onZoomIn()
+          wheelAccumulator.current = 0
+        } else if (wheelAccumulator.current >= 10) {
+          callbacks.onZoomOut && callbacks.onZoomOut()
+          wheelAccumulator.current = 0
+        }
+      }
+    }
+
+    const handleGestureChange = (event: GestureEvent) => {
+      const scaleChange = event.scale - lastScale.current
+
+      // Trigger zoom if scale change exceeds sensitivity threshold
+      if (Math.abs(scaleChange) >= sensitivity * 0.1) {
+        if (scaleChange > 0) {
+          callbacks.onZoomIn && callbacks.onZoomIn()
+        } else if (scaleChange < 0) {
+          callbacks.onZoomOut && callbacks.onZoomOut()
+        }
+        lastScale.current = event.scale // Update last scale
+      }
+    }
+
+    const handleGestureEnd = () => {
+      lastScale.current = 1 // Reset scale after gesture ends
+    }
+
+    // Attach event listeners
+    window.addEventListener('wheel', handleWheel, { passive: false })
+    window.addEventListener('gesturechange', handleGestureChange as EventListener)
+    window.addEventListener('gestureend', handleGestureEnd as EventListener)
+
+    return () => {
+      // Cleanup event listeners
+      window.removeEventListener('wheel', handleWheel)
+      window.removeEventListener('gesturechange', handleGestureChange as EventListener)
+      window.removeEventListener('gestureend', handleGestureEnd as EventListener)
+    }
+  }, [callbacks, sensitivity])
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import '@/assets/scss/global.scss'
-import '@/assets/scss/animations.scss'
 import { Routes } from './routes'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(

--- a/src/layouts/AppLayout/index.tsx
+++ b/src/layouts/AppLayout/index.tsx
@@ -1,7 +1,7 @@
 import { FC, useEffect, useState } from 'react'
 import { WindowTitlebar } from '@/components/WindowTitlebar'
 import { WindowContent } from '@/components/WindowContent'
-import { Outlet } from 'react-router-dom'
+import { Outlet, useNavigate } from 'react-router-dom'
 import { usePickerStore } from '@/store/picker.store'
 import { Window } from '@tauri-apps/api/window'
 import { UnlistenFn } from '@tauri-apps/api/event'
@@ -24,6 +24,7 @@ import { generateColorLabel } from '@/utils/color'
 import { registerGlobalShortcuts, unregisterGlobalShortcuts } from '@/utils/shortcuts'
 import { preparePickerForOpen } from '@/utils/picker.util'
 import { emitToPicker } from '@/utils/emit/picker.emit'
+import { handleOpenWith } from '@/utils/openWith.util'
 
 export const AppLayout: FC = () => {
   const pickerStore = usePickerStore()
@@ -32,6 +33,7 @@ export const AppLayout: FC = () => {
   const settingsStore = useSettingsStore()
   const [isPickerLoopActive, setIsPickerLoopActive] = useState(false)
   const platform = getPlatform()
+  const navigate = useNavigate()
 
   useEffect(() => {
     if (pickerStore.isPicking) {
@@ -144,6 +146,15 @@ export const AppLayout: FC = () => {
       listenInMain('preview_canceled', () => {
         pickerStore.closePicker()
       })
+    )
+
+    listeners.push(
+      listenInMain('open_file', (payload) =>
+        handleOpenWith(payload, (palette) => {
+          palettesStore.addPalette(palette)
+          navigate(`/palettes/${palette.id}`)
+        })
+      )
     )
 
     return () => {

--- a/src/layouts/AppLayout/index.tsx
+++ b/src/layouts/AppLayout/index.tsx
@@ -71,7 +71,9 @@ export const AppLayout: FC = () => {
     disableDefaultContextMenu()
     registerGlobalShortcuts({
       triggerOpenPicker: () => {
-        preparePickerForOpen(() => pickerStore.openPicker({ target: 'HOME' }))
+        if (!pickerStore.isPicking) {
+          preparePickerForOpen(() => pickerStore.openPicker({ target: 'HOME' }))
+        }
       },
     })
 

--- a/src/layouts/PickerLayout/index.tsx
+++ b/src/layouts/PickerLayout/index.tsx
@@ -124,6 +124,8 @@ export const PickerLayout: FC = () => {
       previewSize={previewSize}
       image={image}
       showGuidelines={showGuidelines}
+      onZoomIn={zoomIn}
+      onZoomOut={zoomOut}
     />
   )
 }

--- a/src/layouts/PickerLayout/index.tsx
+++ b/src/layouts/PickerLayout/index.tsx
@@ -1,10 +1,11 @@
-import { FC, useEffect, useState } from 'react'
+import { FC, useEffect, useRef, useState } from 'react'
 import { UnlistenFn } from '@tauri-apps/api/event'
 import { rgbToHex } from '@/utils/color'
 import { disableDefaultContextMenu } from '@/utils/contextMenu.util'
 import { emitToMain } from '@/utils/emit/main.emit'
 import { PickerPreview } from '@/components/PickerPreview'
 import { listenInPicker } from '@/utils/emit/picker.emit'
+import { IPickerPreviewRef } from '@/components/PickerPreview/props'
 
 export const PickerLayout: FC = () => {
   const [image, setImage] = useState('')
@@ -12,8 +13,11 @@ export const PickerLayout: FC = () => {
   const [previewSize, setPreviewSize] = useState(1)
   const [showGuidelines, setShowGuidelines] = useState(false)
   const [isHoldingShift, setIsHoldingShift] = useState(false)
+  const pickerPreviewRef = useRef<IPickerPreviewRef>(null)
 
   const listenKeyPress = (e: KeyboardEvent) => {
+    e.preventDefault()
+
     switch (e.key) {
       case 'Escape':
         cancel()
@@ -114,11 +118,13 @@ export const PickerLayout: FC = () => {
   }
 
   const cancel = () => {
-    emitToMain({ cmd: 'preview_canceled', payload: {} })
+    pickerPreviewRef.current?.showCursor()
+    setTimeout(() => emitToMain({ cmd: 'preview_canceled', payload: {} }))
   }
 
   return (
     <PickerPreview
+      ref={pickerPreviewRef}
       colorHex={color}
       onClick={() => pickColor(false)}
       previewSize={previewSize}

--- a/src/pages/ColorPage/index.tsx
+++ b/src/pages/ColorPage/index.tsx
@@ -80,7 +80,7 @@ export const ColorPage: FC = () => {
     <Stack dir="vertical" gap="medium" grow padding="medium">
       <ColorCard color={color} onColorChange={onColorChange} />
       <ColorPicker hexValue={color.hex} onChange={(hex) => setColor({ ...color, hex })} grow />
-      <ColorInput colorHex={color.hex} />
+      <ColorInput colorHex={color.hex} onChange={(hex) => setColor({ ...color, hex })} />
       <Stack>
         <Button label="Cancel" onClick={onCancel} grow />
         <Button label={params.colorId ? 'Save' : 'Add'} onClick={onSave} grow />

--- a/src/pages/ColorPage/index.tsx
+++ b/src/pages/ColorPage/index.tsx
@@ -10,6 +10,7 @@ import { defaultColor, generateColorLabel } from '@/utils/color'
 import { usePalettesStore } from '@/store/palettes.store'
 import { IColor } from '@/types/color.types'
 import { ColorInput } from '@/components/ColorInput'
+import { Scroller } from '@/components/Scroller'
 
 export const ColorPage: FC = () => {
   const params = useParams<{ paletteId?: string; colorId?: string }>()
@@ -77,14 +78,18 @@ export const ColorPage: FC = () => {
   }
 
   return (
-    <Stack dir="vertical" gap="medium" grow padding="medium">
-      <ColorCard color={color} onColorChange={onColorChange} />
-      <ColorPicker hexValue={color.hex} onChange={(hex) => setColor({ ...color, hex })} grow />
-      <ColorInput colorHex={color.hex} onChange={(hex) => setColor({ ...color, hex })} />
-      <Stack>
-        <Button label="Cancel" onClick={onCancel} grow />
-        <Button label={params.colorId ? 'Save' : 'Add'} onClick={onSave} grow />
-      </Stack>
+    <Stack dir="vertical" gap="none" grow>
+      <Scroller>
+        <Stack dir="vertical" gap="medium" grow padding="medium">
+          <ColorCard color={color} onColorChange={onColorChange} />
+          <ColorPicker hexValue={color.hex} onChange={(hex) => setColor({ ...color, hex })} grow />
+          <ColorInput colorHex={color.hex} onChange={(hex) => setColor({ ...color, hex })} />
+          <Stack>
+            <Button label="Cancel" onClick={onCancel} grow />
+            <Button label={params.colorId ? 'Save' : 'Add'} onClick={onSave} grow />
+          </Stack>
+        </Stack>
+      </Scroller>
     </Stack>
   )
 }

--- a/src/pages/ColorPage/index.tsx
+++ b/src/pages/ColorPage/index.tsx
@@ -9,6 +9,7 @@ import { generateRandomUuid } from '@/utils/uuid.util'
 import { defaultColor, generateColorLabel } from '@/utils/color'
 import { usePalettesStore } from '@/store/palettes.store'
 import { IColor } from '@/types/color.types'
+import { ColorInput } from '@/components/ColorInput'
 
 export const ColorPage: FC = () => {
   const params = useParams<{ paletteId?: string; colorId?: string }>()
@@ -79,6 +80,7 @@ export const ColorPage: FC = () => {
     <Stack dir="vertical" gap="medium" grow padding="medium">
       <ColorCard color={color} onColorChange={onColorChange} />
       <ColorPicker hexValue={color.hex} onChange={(hex) => setColor({ ...color, hex })} grow />
+      <ColorInput colorHex={color.hex} />
       <Stack>
         <Button label="Cancel" onClick={onCancel} grow />
         <Button label={params.colorId ? 'Save' : 'Add'} onClick={onSave} grow />

--- a/src/pages/ColorPage/index.tsx
+++ b/src/pages/ColorPage/index.tsx
@@ -1,7 +1,7 @@
 import { ColorCard } from '@/components/ColorCard'
 import { Stack } from '@/components/Stack'
 import { useColorsStore } from '@/store/colors.store'
-import { FC, useEffect, useState } from 'react'
+import { FC, useEffect, useMemo, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { Button } from '@/components/Button'
 import { ColorPicker } from '@/components/ColorPicker'
@@ -10,31 +10,41 @@ import { defaultColor, generateColorLabel } from '@/utils/color'
 import { usePalettesStore } from '@/store/palettes.store'
 import { IColor } from '@/types/color.types'
 
-const DEFAULT_COLOR_NAME = 'New Color'
-
 export const ColorPage: FC = () => {
   const params = useParams<{ paletteId?: string; colorId?: string }>()
   const colorsStore = useColorsStore()
   const palettesStore = usePalettesStore()
   const navigate = useNavigate()
 
-  const [color, setColor] = useState<IColor>(
-    (params.paletteId
-      ? palettesStore.palettes.find((palette) => palette.id === params.paletteId)?.colors || []
-      : colorsStore.colors
-    ).find((color) => color.id === params.colorId) || {
+  const emptyColor = useMemo(
+    () => ({
       id: generateRandomUuid(),
-      label: DEFAULT_COLOR_NAME,
+      label: '',
       hex: defaultColor,
-    }
+    }),
+    []
   )
 
+  const initialColor = useMemo(
+    () =>
+      params.colorId
+        ? (params.paletteId
+            ? palettesStore.palettes.find((palette) => palette.id === params.paletteId)?.colors || []
+            : colorsStore.colors
+          ).find((color) => color.id === params.colorId) || emptyColor
+        : emptyColor,
+    [params.colorId, params.paletteId, palettesStore.palettes, colorsStore.colors]
+  )
+
+  const [color, setColor] = useState<IColor>(initialColor)
+  const [isCustomNameSet, setIsCustomNameSet] = useState(!!initialColor.label)
+
   useEffect(() => {
-    if (color.label === DEFAULT_COLOR_NAME) {
+    if (!isCustomNameSet) {
       const label = generateColorLabel(color.hex)
       setColor({ ...color, label })
     }
-  }, [color.hex])
+  }, [isCustomNameSet, color.hex])
 
   const onCancel = () => {
     navigate(-1)
@@ -57,9 +67,17 @@ export const ColorPage: FC = () => {
     navigate(-1)
   }
 
+  const onColorChange = (c: IColor) => {
+    if (!isCustomNameSet && c.label !== color.label) {
+      setIsCustomNameSet(true)
+    }
+
+    setColor(c)
+  }
+
   return (
     <Stack dir="vertical" gap="medium" grow padding="medium">
-      <ColorCard color={color} onColorChange={setColor} />
+      <ColorCard color={color} onColorChange={onColorChange} />
       <ColorPicker hexValue={color.hex} onChange={(hex) => setColor({ ...color, hex })} grow />
       <Stack>
         <Button label="Cancel" onClick={onCancel} grow />

--- a/src/pages/ExportPalettePage/index.tsx
+++ b/src/pages/ExportPalettePage/index.tsx
@@ -14,6 +14,7 @@ import { writeText } from '@tauri-apps/plugin-clipboard-manager'
 import { save } from '@tauri-apps/plugin-dialog'
 import { writeTextFile } from '@tauri-apps/plugin-fs'
 import { ITextareaRef } from '@/components/Textarea/props'
+import { invokeSaveClrFile } from '@/utils/cmd/clr.cmd.util'
 
 export const ExportPalettePage: FC = () => {
   const params = useParams<{ paletteId: string }>()
@@ -45,18 +46,26 @@ export const ExportPalettePage: FC = () => {
   )
 
   const saveFile = async () => {
-    const filePath = await save({
-      title: `Save "${palette.label}"`,
-      filters: [
-        {
-          name: exportPaletteVariant.fileExtension.toUpperCase(),
-          extensions: [exportPaletteVariant.fileExtension],
-        },
-      ],
-    })
+    switch (exportPaletteVariant.id) {
+      case EExportPaletteVariant.APPLE_CLR: {
+        invokeSaveClrFile(palette)
+        break
+      }
+      default: {
+        const filePath = await save({
+          title: `Save "${palette.label}"`,
+          filters: [
+            {
+              name: exportPaletteVariant.fileExtension.toUpperCase(),
+              extensions: [exportPaletteVariant.fileExtension],
+            },
+          ],
+        })
 
-    if (filePath) {
-      writeTextFile(filePath, fileContent)
+        if (filePath) {
+          writeTextFile(filePath, fileContent)
+        }
+      }
     }
   }
 
@@ -105,7 +114,7 @@ export const ExportPalettePage: FC = () => {
       <Stack>
         <Button label="Cancel" onClick={goBack} grow />
         <Button label="Export" onClick={saveFile} grow />
-        <Button onClick={copyContent} iconPre={Copy} padding="small" />
+        {exportPaletteVariant.allowCopy && <Button onClick={copyContent} iconPre={Copy} padding="small" />}
       </Stack>
     </Stack>
   )

--- a/src/pages/ExportPalettePage/index.tsx
+++ b/src/pages/ExportPalettePage/index.tsx
@@ -1,5 +1,5 @@
 import { Stack } from '@/components/Stack'
-import { FC, useState } from 'react'
+import { FC, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { Button } from '@/components/Button'
 import { usePalettesStore } from '@/store/palettes.store'
@@ -13,6 +13,7 @@ import { Copy } from '@phosphor-icons/react'
 import { writeText } from '@tauri-apps/plugin-clipboard-manager'
 import { save } from '@tauri-apps/plugin-dialog'
 import { writeTextFile } from '@tauri-apps/plugin-fs'
+import { ITextareaRef } from '@/components/Textarea/props'
 
 export const ExportPalettePage: FC = () => {
   const params = useParams<{ paletteId: string }>()
@@ -21,6 +22,7 @@ export const ExportPalettePage: FC = () => {
   const settingsStore = useSettingsStore()
   const [exportVariant, setExportVariant] = useState(EExportPaletteVariant.PLAINCOLOR_JSON)
   const [colorFormat, setColorFormat] = useState(settingsStore.defaultCopyVariant)
+  const textareaRef = useRef<ITextareaRef>(null)
 
   const palette = palettesStore.palettes.find((palette) => palette.id === params.paletteId)
 
@@ -51,6 +53,7 @@ export const ExportPalettePage: FC = () => {
 
   const copyContent = () => {
     writeText(fileContent)
+    textareaRef.current?.showOverlayMessage('Copied')
   }
 
   return (
@@ -68,7 +71,7 @@ export const ExportPalettePage: FC = () => {
           onChange={(options) => setColorFormat(options[0])}
           fullWidth
         />
-        <Textarea readonly value={fileContent} />
+        <Textarea readonly value={fileContent} ref={textareaRef} />
       </Stack>
       <Stack>
         <Button label="Cancel" onClick={goBack} grow />

--- a/src/pages/ExportPalettePage/index.tsx
+++ b/src/pages/ExportPalettePage/index.tsx
@@ -60,6 +60,7 @@ export const ExportPalettePage: FC = () => {
               extensions: [exportPaletteVariant.fileExtension],
             },
           ],
+          defaultPath: palette.label,
         })
 
         if (filePath) {

--- a/src/pages/ExportPalettePage/index.tsx
+++ b/src/pages/ExportPalettePage/index.tsx
@@ -1,5 +1,5 @@
 import { Stack } from '@/components/Stack'
-import { FC, useRef, useState } from 'react'
+import { FC, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { Button } from '@/components/Button'
 import { usePalettesStore } from '@/store/palettes.store'
@@ -24,7 +24,10 @@ export const ExportPalettePage: FC = () => {
   const [colorFormat, setColorFormat] = useState(settingsStore.defaultCopyVariant)
   const textareaRef = useRef<ITextareaRef>(null)
 
-  const palette = palettesStore.palettes.find((palette) => palette.id === params.paletteId)
+  const palette = useMemo(
+    () => palettesStore.palettes.find((palette) => palette.id === params.paletteId),
+    [palettesStore.palettes, params.paletteId]
+  )
 
   if (!palette) return null
 
@@ -32,8 +35,14 @@ export const ExportPalettePage: FC = () => {
     navigate(`/palettes/${palette.id}`)
   }
 
-  const exportPaletteVariant = exportPaletteVariants.find((epv) => epv.id === exportVariant)!
-  const fileContent = exportPalette(exportVariant, palette, colorFormat)
+  const exportPaletteVariant = useMemo(
+    () => exportPaletteVariants.find((epv) => epv.id === exportVariant)!,
+    [exportVariant]
+  )
+  const fileContent = useMemo(
+    () => exportPalette(exportVariant, palette, colorFormat),
+    [exportVariant, palette, colorFormat]
+  )
 
   const saveFile = async () => {
     const filePath = await save({
@@ -56,6 +65,24 @@ export const ExportPalettePage: FC = () => {
     textareaRef.current?.showOverlayMessage('Copied')
   }
 
+  const filteredCopyVariants = useMemo(
+    () =>
+      exportPaletteVariant.availableColorProfiles === 'all'
+        ? copyVariants
+        : copyVariants.filter((cp) =>
+            Array.isArray(exportPaletteVariant.availableColorProfiles)
+              ? exportPaletteVariant.availableColorProfiles.find((acp) => cp.id === acp)
+              : []
+          ),
+    [exportPaletteVariant]
+  )
+
+  useEffect(() => {
+    if (filteredCopyVariants.length) {
+      setColorFormat(filteredCopyVariants[0].id)
+    }
+  }, [exportVariant])
+
   return (
     <Stack dir="vertical" gap="medium" grow padding="medium">
       <Stack grow dir="vertical">
@@ -65,12 +92,14 @@ export const ExportPalettePage: FC = () => {
           onChange={(options) => setExportVariant(options[0])}
           fullWidth
         />
-        <Select
-          options={copyVariants}
-          value={[colorFormat]}
-          onChange={(options) => setColorFormat(options[0])}
-          fullWidth
-        />
+        {filteredCopyVariants.length > 0 && (
+          <Select
+            options={filteredCopyVariants}
+            value={[colorFormat]}
+            onChange={(options) => setColorFormat(options[0])}
+            fullWidth
+          />
+        )}
         <Textarea readonly value={fileContent} ref={textareaRef} />
       </Stack>
       <Stack>

--- a/src/pages/ImportPalettePage/index.tsx
+++ b/src/pages/ImportPalettePage/index.tsx
@@ -32,7 +32,11 @@ export const ImportPalettePage: FC = () => {
     setIsLoading(true)
     try {
       const importedPalette = await importPalette(importVariant)
-      palettesStore.updatePalette(palette.id, { ...palette, colors: importedPalette.colors.concat(palette.colors) })
+      palettesStore.updatePalette(palette.id, {
+        ...palette,
+        label: importedPalette.label,
+        colors: importedPalette.colors.concat(palette.colors),
+      })
       goBack()
     } catch (err: any) {
       console.error(err)

--- a/src/pages/PalettePage/index.tsx
+++ b/src/pages/PalettePage/index.tsx
@@ -76,6 +76,8 @@ export const PalettePage: FC = () => {
             onInputBlur={() => onPaletteChange({ ...palette, label: sanitizeLabel(palette.label) })}
             align="center"
             grow
+            textWrap={false}
+            maxWidth={204}
           />
         </Stack>
       </Header>

--- a/src/pages/PalettePage/index.tsx
+++ b/src/pages/PalettePage/index.tsx
@@ -20,6 +20,7 @@ import { IColor } from '@/types/color.types'
 import { usePickerStore } from '@/store/picker.store'
 import { Scroller } from '@/components/Scroller'
 import { preparePickerForOpen } from '@/utils/picker.util'
+import { sanitizeLabel } from '@/utils/label.util'
 
 export const PalettePage: FC = () => {
   const params = useParams<{ paletteId: string }>()
@@ -72,6 +73,7 @@ export const PalettePage: FC = () => {
             text={palette.label}
             editable
             onTextChange={(label) => onPaletteChange({ ...palette, label })}
+            onInputBlur={() => onPaletteChange({ ...palette, label: sanitizeLabel(palette.label) })}
             align="center"
             grow
           />

--- a/src/pages/PalettePage/index.tsx
+++ b/src/pages/PalettePage/index.tsx
@@ -20,7 +20,7 @@ import { IColor } from '@/types/color.types'
 import { usePickerStore } from '@/store/picker.store'
 import { Scroller } from '@/components/Scroller'
 import { preparePickerForOpen } from '@/utils/picker.util'
-import { sanitizeLabel } from '@/utils/label.util'
+import { sanitizeLabel } from '@/utils/sanitize.util'
 
 export const PalettePage: FC = () => {
   const params = useParams<{ paletteId: string }>()

--- a/src/pages/PalettePage/index.tsx
+++ b/src/pages/PalettePage/index.tsx
@@ -64,6 +64,10 @@ export const PalettePage: FC = () => {
     palettesStore.updatePalette(palette.id, { ...palette, view: palette.view === 'grid' ? 'list' : 'grid' })
   }
 
+  const onPaletteNameInputBlur = () => {
+    onPaletteChange({ ...palette, label: sanitizeLabel(palette.label) || 'My Palette' })
+  }
+
   return (
     <Stack dir="vertical" gap="none" grow>
       <Header extraPaddingRight>
@@ -73,7 +77,7 @@ export const PalettePage: FC = () => {
             text={palette.label}
             editable
             onTextChange={(label) => onPaletteChange({ ...palette, label })}
-            onInputBlur={() => onPaletteChange({ ...palette, label: sanitizeLabel(palette.label) })}
+            onInputBlur={onPaletteNameInputBlur}
             align="center"
             grow
             textWrap={false}

--- a/src/pages/SettingsPage/index.tsx
+++ b/src/pages/SettingsPage/index.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/Button'
 import { Text } from '@/components/Text'
 import { Select } from '@/components/Select'
 import { copyVariants, formatCopyText } from '@/utils/copyVariants.util'
-import { EColorProfile, useSettingsStore } from '@/store/settings.store'
+import { EScreenColorProfile, useSettingsStore } from '@/store/settings.store'
 import { getPlatform } from '@/utils/tauri.util'
 import {
   invokeRequestMacosScreenRecordingPermission,
@@ -49,8 +49,8 @@ export const SettingsPage: FC = () => {
   }
 
   const colorProfiles = [
-    { id: EColorProfile.SRGB, label: 'sRGB (Default)' },
-    { id: EColorProfile.SYSTEM, label: 'System' },
+    { id: EScreenColorProfile.SRGB, label: 'sRGB (Default)' },
+    { id: EScreenColorProfile.SYSTEM, label: 'System' },
   ]
 
   const exampleColor = '3D061A'

--- a/src/picker.tsx
+++ b/src/picker.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import '@/assets/scss/global.scss'
+import '@/assets/scss/animations.scss'
 import { PickerLayout } from '@/layouts/PickerLayout'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(

--- a/src/picker.tsx
+++ b/src/picker.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import '@/assets/scss/global.scss'
-import '@/assets/scss/animations.scss'
 import { PickerLayout } from '@/layouts/PickerLayout'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(

--- a/src/store/colors.store.ts
+++ b/src/store/colors.store.ts
@@ -1,5 +1,5 @@
 import { IColor } from '@/types/color.types'
-import { defaultColor, generateColorLabel } from '@/utils/color'
+import { predefinedColors } from '@/utils/color'
 import { generateRandomUuid } from '@/utils/uuid.util'
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
@@ -16,7 +16,7 @@ interface IColorsState {
 export const useColorsStore = create<IColorsState>()(
   persist(
     (set) => ({
-      colors: [{ id: 'default', label: generateColorLabel(defaultColor), hex: defaultColor }],
+      colors: predefinedColors,
       addColor: (color) => set((state) => ({ colors: [color, ...state.colors] })),
       removeColor: (colorId) => set((state) => ({ colors: state.colors.filter((color) => color.id !== colorId) })),
       updateColor: (colorId, payload) =>

--- a/src/store/colors.store.ts
+++ b/src/store/colors.store.ts
@@ -1,5 +1,5 @@
 import { IColor } from '@/types/color.types'
-import { defaultColor } from '@/utils/color'
+import { defaultColor, generateColorLabel } from '@/utils/color'
 import { generateRandomUuid } from '@/utils/uuid.util'
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
@@ -16,7 +16,7 @@ interface IColorsState {
 export const useColorsStore = create<IColorsState>()(
   persist(
     (set) => ({
-      colors: [{ id: 'default', label: 'Mine Shaft', hex: defaultColor }],
+      colors: [{ id: 'default', label: generateColorLabel(defaultColor), hex: defaultColor }],
       addColor: (color) => set((state) => ({ colors: [color, ...state.colors] })),
       removeColor: (colorId) => set((state) => ({ colors: state.colors.filter((color) => color.id !== colorId) })),
       updateColor: (colorId, payload) =>

--- a/src/store/palettes.store.ts
+++ b/src/store/palettes.store.ts
@@ -1,5 +1,6 @@
 import { IColor } from '@/types/color.types'
 import { IPalette } from '@/types/palette.types'
+import { predefinedPalettes } from '@/utils/palette'
 import { generateRandomUuid } from '@/utils/uuid.util'
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
@@ -19,7 +20,7 @@ interface IColorsState {
 export const usePalettesStore = create<IColorsState>()(
   persist(
     (set) => ({
-      palettes: [],
+      palettes: predefinedPalettes,
       addPalette: (palette) => set((state) => ({ palettes: [palette, ...state.palettes] })),
       removePalette: (paletteId) =>
         set((state) => ({ palettes: state.palettes.filter((palette) => palette.id !== paletteId) })),

--- a/src/store/settings.store.ts
+++ b/src/store/settings.store.ts
@@ -2,7 +2,7 @@ import { ECopyVariant } from '@/types/settings.types'
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
-export enum EColorProfile {
+export enum EScreenColorProfile {
   SYSTEM = 'SYSTEM',
   SRGB = 'SRGB',
 }
@@ -14,8 +14,8 @@ interface ISettingsState {
   setDefaultCopyVariant: (defaultCopyVariant: ECopyVariant) => void
   pickerPreviewSize: number
   setPickerPreviewSize: (pickerPreviewSize: number) => void
-  pickerColorProfile: EColorProfile
-  setPickerColorProfile: (pickerColorProfile: EColorProfile) => void
+  pickerColorProfile: EScreenColorProfile
+  setPickerColorProfile: (pickerColorProfile: EScreenColorProfile) => void
   showGuidelines: boolean
   setShowGuidelines: (showGuidelines: boolean) => void
 }
@@ -29,7 +29,7 @@ export const useSettingsStore = create<ISettingsState>()(
       setDefaultCopyVariant: (defaultCopyVariant) => set(() => ({ defaultCopyVariant })),
       pickerPreviewSize: 12,
       setPickerPreviewSize: (pickerPreviewSize) => set(() => ({ pickerPreviewSize })),
-      pickerColorProfile: EColorProfile.SRGB,
+      pickerColorProfile: EScreenColorProfile.SRGB,
       setPickerColorProfile: (pickerColorProfile) => set(() => ({ pickerColorProfile })),
       showGuidelines: false,
       setShowGuidelines: (showGuidelines) => set(() => ({ showGuidelines })),

--- a/src/types/palette.types.ts
+++ b/src/types/palette.types.ts
@@ -13,6 +13,7 @@ export enum EExportPaletteVariant {
   CSS_VARS = 'CSS_VARS',
   SASS_VARS = 'SASS_VARS',
   JS_OBJECT = 'JS_OBJECT',
+  APPLE_CLR = 'APPLE_CLR',
 }
 
 export enum EImportPaletteVariant {

--- a/src/types/palette.types.ts
+++ b/src/types/palette.types.ts
@@ -17,6 +17,7 @@ export enum EExportPaletteVariant {
 
 export enum EImportPaletteVariant {
   PLAINCOLOR_JSON = 'PLAINCOLOR_JSON',
+  APPLE_COLORS_PHP = 'APPLE_COLORS_PHP',
   TAILWIND_COLORS_JS = 'TAILWIND_COLORS_JS',
   MUI_COLORS_JS = 'MUI_COLORS_JS',
 }

--- a/src/types/palette.types.ts
+++ b/src/types/palette.types.ts
@@ -17,6 +17,7 @@ export enum EExportPaletteVariant {
 
 export enum EImportPaletteVariant {
   PLAINCOLOR_JSON = 'PLAINCOLOR_JSON',
+  APPLE_CLR = 'APPLE_CLR',
   APPLE_COLORS_PHP = 'APPLE_COLORS_PHP',
   TAILWIND_COLORS_JS = 'TAILWIND_COLORS_JS',
   MUI_COLORS_JS = 'MUI_COLORS_JS',

--- a/src/types/palette.types.ts
+++ b/src/types/palette.types.ts
@@ -19,3 +19,5 @@ export enum EImportPaletteVariant {
   PLAINCOLOR_JSON = 'PLAINCOLOR_JSON',
   TAILWIND_COLORS_JS = 'TAILWIND_COLORS_JS',
 }
+
+export type IPlainColorPaletteJson = Omit<IPalette, 'id' | 'colors' | 'view'> & { colors: Omit<IColor, 'id'>[] }

--- a/src/types/palette.types.ts
+++ b/src/types/palette.types.ts
@@ -18,6 +18,9 @@ export enum EExportPaletteVariant {
 export enum EImportPaletteVariant {
   PLAINCOLOR_JSON = 'PLAINCOLOR_JSON',
   TAILWIND_COLORS_JS = 'TAILWIND_COLORS_JS',
+  MUI_COLORS_JS = 'MUI_COLORS_JS',
 }
 
-export type IPlainColorPaletteJson = Omit<IPalette, 'id' | 'colors' | 'view'> & { colors: Omit<IColor, 'id'>[] }
+export type TPlainColorPaletteJson = Omit<IPalette, 'id' | 'colors' | 'view'> & { colors: Omit<IColor, 'id'>[] }
+
+export type TPaletteImporterResult = Omit<IPalette, 'id' | 'view'>

--- a/src/utils/cmd/clr.cmd.util.ts
+++ b/src/utils/cmd/clr.cmd.util.ts
@@ -1,0 +1,5 @@
+import { invokeCmd } from '.'
+
+export const invokeLoadClrFile = async () => {
+  return invokeCmd<string>('load_clr_file')
+}

--- a/src/utils/cmd/clr.cmd.util.ts
+++ b/src/utils/cmd/clr.cmd.util.ts
@@ -2,8 +2,8 @@ import { IPalette } from '@/types/palette.types'
 import { invokeCmd } from '.'
 import { IClrResponseObject } from '@/utils/palette/importers/clr.importer'
 
-export const invokeLoadClrFile = async (filePath: string) => {
-  return invokeCmd<string>('load_clr_file', { filePath })
+export const invokeLoadClrFile = async (file: string) => {
+  return invokeCmd<string>('load_clr_file', { file })
 }
 
 export const invokeSaveClrFile = async (palette: IPalette) => {

--- a/src/utils/cmd/clr.cmd.util.ts
+++ b/src/utils/cmd/clr.cmd.util.ts
@@ -2,8 +2,8 @@ import { IPalette } from '@/types/palette.types'
 import { invokeCmd } from '.'
 import { IClrResponseObject } from '@/utils/palette/importers/clr.importer'
 
-export const invokeLoadClrFile = async () => {
-  return invokeCmd<string>('load_clr_file')
+export const invokeLoadClrFile = async (filePath: string) => {
+  return invokeCmd<string>('load_clr_file', { filePath })
 }
 
 export const invokeSaveClrFile = async (palette: IPalette) => {

--- a/src/utils/cmd/clr.cmd.util.ts
+++ b/src/utils/cmd/clr.cmd.util.ts
@@ -1,5 +1,18 @@
+import { IPalette } from '@/types/palette.types'
 import { invokeCmd } from '.'
+import { IClrResponseObject } from '@/utils/palette/importers/clr.importer'
 
 export const invokeLoadClrFile = async () => {
   return invokeCmd<string>('load_clr_file')
+}
+
+export const invokeSaveClrFile = async (palette: IPalette) => {
+  const json: IClrResponseObject = {
+    paletteName: palette.label,
+    colorList: palette.colors.reduce((prev, cur) => {
+      return { ...prev, [cur.label]: `#${cur.hex.toUpperCase()}` }
+    }, {}),
+  }
+
+  return invokeCmd<string>('save_clr_file', { json: JSON.stringify(json) })
 }

--- a/src/utils/cmd/index.ts
+++ b/src/utils/cmd/index.ts
@@ -8,6 +8,7 @@ export type TInvokeCmd =
   | 'check_macos_screen_recording_permission'
   | 'request_macos_screen_recording_permission'
   | 'open_macos_screen_recording_settings'
+  | 'load_clr_file'
 
 export const invokeCmd = <T>(cmd: TInvokeCmd, args?: InvokeArgs) => {
   return invoke<T>(cmd, args)

--- a/src/utils/cmd/index.ts
+++ b/src/utils/cmd/index.ts
@@ -9,6 +9,7 @@ export type TInvokeCmd =
   | 'request_macos_screen_recording_permission'
   | 'open_macos_screen_recording_settings'
   | 'load_clr_file'
+  | 'save_clr_file'
 
 export const invokeCmd = <T>(cmd: TInvokeCmd, args?: InvokeArgs) => {
   return invoke<T>(cmd, args)

--- a/src/utils/cmd/picker.cmd.util.ts
+++ b/src/utils/cmd/picker.cmd.util.ts
@@ -1,4 +1,4 @@
-import { EColorProfile } from '@/store/settings.store'
+import { EScreenColorProfile } from '@/store/settings.store'
 import { invokeCmd } from '.'
 
 export const invokeStartPickerLoop = async () => {
@@ -13,6 +13,6 @@ export const invokeSetPickerPreviewSize = async (args: { size: number }) => {
   return invokeCmd<boolean>('set_picker_preview_size', args)
 }
 
-export const invokeSetPickerColorProfile = async (args: { profile: EColorProfile }) => {
+export const invokeSetPickerColorProfile = async (args: { profile: EScreenColorProfile }) => {
   return invokeCmd<boolean>('set_picker_color_profile', args)
 }

--- a/src/utils/color/index.ts
+++ b/src/utils/color/index.ts
@@ -2,6 +2,8 @@ import rgbHex from 'rgb-hex'
 import namer from 'color-namer'
 import { colorIsDark } from 'color-is-dark'
 import { hexToRgbObj } from './rgb.color.util'
+import { IColor } from '@/types/color.types'
+import { generateRandomUuid } from '@/utils/uuid.util'
 
 export const defaultColor = '2c2c2c'
 
@@ -37,3 +39,10 @@ export const isDark = (colorHex: string) => {
 export const generateColorLabel = (colorHex: string) => {
   return namer(colorHex).ntc[0].name
 }
+
+const predefinedColors1 = ['9b5de5', 'f15bb5', 'fee440', '00bbf9', '00f5d4']
+export const predefinedColors: IColor[] = predefinedColors1.map((hex) => ({
+  id: generateRandomUuid(),
+  hex,
+  label: generateColorLabel(hex),
+}))

--- a/src/utils/color/index.ts
+++ b/src/utils/color/index.ts
@@ -40,7 +40,7 @@ export const generateColorLabel = (colorHex: string) => {
   return namer(colorHex).ntc[0].name
 }
 
-const predefinedColors1 = ['9b5de5', 'f15bb5', 'fee440', '00bbf9', '00f5d4']
+const predefinedColors1 = ['9b5de5', 'f15bb5', 'fee440']
 export const predefinedColors: IColor[] = predefinedColors1.map((hex) => ({
   id: generateRandomUuid(),
   hex,

--- a/src/utils/emit/main.emit.ts
+++ b/src/utils/emit/main.emit.ts
@@ -6,6 +6,7 @@ interface TEmitToMainPayload {
   preview_zoom_out: {}
   preview_canceled: {}
   toggle_guidelines: { show: boolean }
+  open_file: string
 }
 
 export type TEmitToMainCmd =
@@ -14,6 +15,7 @@ export type TEmitToMainCmd =
   | { cmd: 'preview_zoom_out'; payload: TEmitToMainPayload['preview_zoom_out'] }
   | { cmd: 'preview_canceled'; payload: TEmitToMainPayload['preview_canceled'] }
   | { cmd: 'toggle_guidelines'; payload: TEmitToMainPayload['toggle_guidelines'] }
+  | { cmd: 'open_file'; payload: TEmitToMainPayload['open_file'] }
 
 export const emitToMain = (cmd: TEmitToMainCmd) => {
   return emitTo('main', cmd.cmd, cmd.payload)
@@ -24,6 +26,7 @@ export const listenInMain = <K extends keyof TEmitToMainPayload>(
   callback: (payload: TEmitToMainPayload[K]) => void
 ) => {
   return listen(cmd, ({ payload }) => {
+    console.info('listenInMain', cmd, payload)
     callback(payload as TEmitToMainPayload[K])
   })
 }

--- a/src/utils/emit/main.emit.ts
+++ b/src/utils/emit/main.emit.ts
@@ -6,7 +6,7 @@ interface TEmitToMainPayload {
   preview_zoom_out: {}
   preview_canceled: {}
   toggle_guidelines: { show: boolean }
-  open_file: string
+  trigger_deep_link: string[]
 }
 
 export type TEmitToMainCmd =
@@ -15,7 +15,7 @@ export type TEmitToMainCmd =
   | { cmd: 'preview_zoom_out'; payload: TEmitToMainPayload['preview_zoom_out'] }
   | { cmd: 'preview_canceled'; payload: TEmitToMainPayload['preview_canceled'] }
   | { cmd: 'toggle_guidelines'; payload: TEmitToMainPayload['toggle_guidelines'] }
-  | { cmd: 'open_file'; payload: TEmitToMainPayload['open_file'] }
+  | { cmd: 'trigger_deep_link'; payload: TEmitToMainPayload['trigger_deep_link'] }
 
 export const emitToMain = (cmd: TEmitToMainCmd) => {
   return emitTo('main', cmd.cmd, cmd.payload)

--- a/src/utils/emit/main.emit.ts
+++ b/src/utils/emit/main.emit.ts
@@ -26,7 +26,6 @@ export const listenInMain = <K extends keyof TEmitToMainPayload>(
   callback: (payload: TEmitToMainPayload[K]) => void
 ) => {
   return listen(cmd, ({ payload }) => {
-    console.info('listenInMain', cmd, payload)
     callback(payload as TEmitToMainPayload[K])
   })
 }

--- a/src/utils/label.util.ts
+++ b/src/utils/label.util.ts
@@ -1,3 +1,0 @@
-export const sanitizeLabel = (label: string) => {
-  return label.trim().replace(/\s\s+/g, ' ')
-}

--- a/src/utils/label.util.ts
+++ b/src/utils/label.util.ts
@@ -1,0 +1,3 @@
+export const sanitizeLabel = (label: string) => {
+  return label.trim().replace(/\s\s+/g, ' ')
+}

--- a/src/utils/openWith.util.ts
+++ b/src/utils/openWith.util.ts
@@ -31,7 +31,7 @@ export const handleOpenWith = async (filePath: string, callback: (palette: IPale
       })
 
       if (file) {
-        return handleOpenWith(file, callback)
+        handleOpenWith(file, callback)
       }
     } else {
       console.error(err)

--- a/src/utils/openWith.util.ts
+++ b/src/utils/openWith.util.ts
@@ -1,0 +1,21 @@
+import { EImportPaletteVariant, IPalette, TPaletteImporterResult } from '@/types/palette.types'
+import { importPalette } from './palette/import.palette'
+import { generateRandomUuid } from './uuid.util'
+
+export const handleOpenWith = async (filePath: string, callback: (palette: IPalette) => void) => {
+  let result: TPaletteImporterResult | null = null
+
+  try {
+    if (filePath.endsWith('.plaincolorjson')) {
+      result = await importPalette(EImportPaletteVariant.PLAINCOLOR_JSON, filePath)
+    } else if (filePath.endsWith('.clr')) {
+      result = await importPalette(EImportPaletteVariant.APPLE_CLR, filePath)
+    }
+  } catch (err: any) {
+    console.error(err)
+  }
+
+  if (result) {
+    callback({ id: generateRandomUuid(), label: result.label, colors: result.colors, view: 'list' })
+  }
+}

--- a/src/utils/openWith.util.ts
+++ b/src/utils/openWith.util.ts
@@ -1,21 +1,49 @@
 import { EImportPaletteVariant, IPalette, TPaletteImporterResult } from '@/types/palette.types'
 import { importPalette } from './palette/import.palette'
 import { generateRandomUuid } from './uuid.util'
+import { open } from '@tauri-apps/plugin-dialog'
 
 export const handleOpenWith = async (filePath: string, callback: (palette: IPalette) => void) => {
-  let result: TPaletteImporterResult | null = null
-
   try {
+    if (typeof filePath !== 'string') return
+
+    if (filePath.startsWith('file://')) filePath = filePath.replace('file://', '')
+
+    let result: TPaletteImporterResult | null = null
+
     if (filePath.endsWith('.plaincolorjson')) {
       result = await importPalette(EImportPaletteVariant.PLAINCOLOR_JSON, filePath)
     } else if (filePath.endsWith('.clr')) {
       result = await importPalette(EImportPaletteVariant.APPLE_CLR, filePath)
     }
-  } catch (err: any) {
-    console.error(err)
-  }
 
-  if (result) {
-    callback({ id: generateRandomUuid(), label: result.label, colors: result.colors, view: 'list' })
+    if (result) {
+      callback({ id: generateRandomUuid(), label: result.label, colors: result.colors, view: 'list' })
+    }
+  } catch (err: any) {
+    if (typeof err === 'string' && err.includes('forbidden path')) {
+      const file = await open({
+        title: 'Import palette from file',
+        filters: [{ name: 'Palette file', extensions: ['plaincolorjson', 'clr'] }],
+        multiple: false,
+        directory: false,
+        defaultPath: filePath,
+      })
+
+      if (file) {
+        return handleOpenWith(file, callback)
+      }
+    } else {
+      console.error(err)
+    }
+  }
+}
+
+export const handleDeepLink = (urls: string[] | null, callback: (palette: IPalette) => void) => {
+  if (urls && urls.length) {
+    const url = urls[0]
+    if (url.startsWith('file://')) {
+      handleOpenWith(decodeURIComponent(url), callback)
+    }
   }
 }

--- a/src/utils/palette/export.palette.ts
+++ b/src/utils/palette/export.palette.ts
@@ -1,5 +1,5 @@
 import { IColor } from '@/types/color.types'
-import { EExportPaletteVariant, IPalette, IPlainColorPaletteJson } from '@/types/palette.types'
+import { EExportPaletteVariant, IPalette, TPlainColorPaletteJson } from '@/types/palette.types'
 import { ECopyVariant } from '@/types/settings.types'
 import { formatCopyText } from '@/utils/copyVariants.util'
 
@@ -111,7 +111,7 @@ export const exportPalette = (
   colorFormat: ECopyVariant
 ) => {
   if (exportVariant === EExportPaletteVariant.PLAINCOLOR_JSON) {
-    const paletteJson: IPlainColorPaletteJson = {
+    const paletteJson: TPlainColorPaletteJson = {
       label: palette.label,
       colors: palette.colors.map((color) => ({ hex: color.hex, label: color.label })),
     }

--- a/src/utils/palette/export.palette.ts
+++ b/src/utils/palette/export.palette.ts
@@ -8,18 +8,21 @@ export const exportPaletteVariants: {
   label: string
   fileExtension: string
   availableColorProfiles: ECopyVariant[] | 'all'
+  allowCopy: boolean
 }[] = [
   {
     id: EExportPaletteVariant.PLAINCOLOR_JSON,
     label: 'PlainColor palette JSON',
     fileExtension: 'json',
     availableColorProfiles: [ECopyVariant.HEX_LOWERCASE_WITHOUT_SHARP],
+    allowCopy: true,
   },
   {
     id: EExportPaletteVariant.JSON,
     label: 'JSON',
     fileExtension: 'json',
     availableColorProfiles: 'all',
+    allowCopy: true,
   },
   {
     id: EExportPaletteVariant.CSS_VARS,
@@ -32,6 +35,7 @@ export const exportPaletteVariants: {
       ECopyVariant.CSS_HSL,
       ECopyVariant.CSS_RGB_DISPLAY_P3,
     ],
+    allowCopy: true,
   },
   {
     id: EExportPaletteVariant.SASS_VARS,
@@ -44,12 +48,21 @@ export const exportPaletteVariants: {
       ECopyVariant.CSS_HSL,
       ECopyVariant.CSS_RGB_DISPLAY_P3,
     ],
+    allowCopy: true,
   },
   {
     id: EExportPaletteVariant.JS_OBJECT,
     label: 'JavaScript object',
     fileExtension: 'js',
     availableColorProfiles: 'all',
+    allowCopy: true,
+  },
+  {
+    id: EExportPaletteVariant.APPLE_CLR,
+    label: 'Apple Color List (.clr)',
+    fileExtension: 'clr',
+    availableColorProfiles: [],
+    allowCopy: false,
   },
 ]
 

--- a/src/utils/palette/export.palette.ts
+++ b/src/utils/palette/export.palette.ts
@@ -1,5 +1,5 @@
 import { IColor } from '@/types/color.types'
-import { EExportPaletteVariant, IPalette } from '@/types/palette.types'
+import { EExportPaletteVariant, IPalette, IPlainColorPaletteJson } from '@/types/palette.types'
 import { ECopyVariant } from '@/types/settings.types'
 import { formatCopyText } from '@/utils/copyVariants.util'
 
@@ -11,13 +11,13 @@ export const exportPaletteVariants: {
 }[] = [
   {
     id: EExportPaletteVariant.PLAINCOLOR_JSON,
-    label: 'PlainColor JSON',
+    label: 'PlainColor palette JSON',
     fileExtension: 'json',
-    availableColorProfiles: [],
+    availableColorProfiles: [ECopyVariant.HEX_LOWERCASE_WITHOUT_SHARP],
   },
   {
     id: EExportPaletteVariant.JSON,
-    label: 'Simple JSON',
+    label: 'JSON',
     fileExtension: 'json',
     availableColorProfiles: 'all',
   },
@@ -111,7 +111,11 @@ export const exportPalette = (
   colorFormat: ECopyVariant
 ) => {
   if (exportVariant === EExportPaletteVariant.PLAINCOLOR_JSON) {
-    return JSON.stringify({ ...palette, id: undefined })
+    const paletteJson: IPlainColorPaletteJson = {
+      label: palette.label,
+      colors: palette.colors.map((color) => ({ hex: color.hex, label: color.label })),
+    }
+    return JSON.stringify(paletteJson)
   } else {
     let prefix = ''
     let postfix = ''

--- a/src/utils/palette/export.palette.ts
+++ b/src/utils/palette/export.palette.ts
@@ -3,12 +3,54 @@ import { EExportPaletteVariant, IPalette } from '@/types/palette.types'
 import { ECopyVariant } from '@/types/settings.types'
 import { formatCopyText } from '@/utils/copyVariants.util'
 
-export const exportPaletteVariants = [
-  { id: EExportPaletteVariant.PLAINCOLOR_JSON, label: 'PlainColor JSON', fileExtension: 'json' },
-  { id: EExportPaletteVariant.JSON, label: 'Simple JSON', fileExtension: 'json' },
-  { id: EExportPaletteVariant.CSS_VARS, label: 'CSS variables', fileExtension: 'css' },
-  { id: EExportPaletteVariant.SASS_VARS, label: 'SASS variables', fileExtension: 'scss' },
-  { id: EExportPaletteVariant.JS_OBJECT, label: 'JavaScript object', fileExtension: 'js' },
+export const exportPaletteVariants: {
+  id: EExportPaletteVariant
+  label: string
+  fileExtension: string
+  availableColorProfiles: ECopyVariant[] | 'all'
+}[] = [
+  {
+    id: EExportPaletteVariant.PLAINCOLOR_JSON,
+    label: 'PlainColor JSON',
+    fileExtension: 'json',
+    availableColorProfiles: [],
+  },
+  {
+    id: EExportPaletteVariant.JSON,
+    label: 'Simple JSON',
+    fileExtension: 'json',
+    availableColorProfiles: 'all',
+  },
+  {
+    id: EExportPaletteVariant.CSS_VARS,
+    label: 'CSS variables',
+    fileExtension: 'css',
+    availableColorProfiles: [
+      ECopyVariant.HEX_WITH_SHARP,
+      ECopyVariant.HEX_LOWERCASE_WITH_SHARP,
+      ECopyVariant.CSS_RGB,
+      ECopyVariant.CSS_HSL,
+      ECopyVariant.CSS_RGB_DISPLAY_P3,
+    ],
+  },
+  {
+    id: EExportPaletteVariant.SASS_VARS,
+    label: 'SASS variables',
+    fileExtension: 'scss',
+    availableColorProfiles: [
+      ECopyVariant.HEX_WITH_SHARP,
+      ECopyVariant.HEX_LOWERCASE_WITH_SHARP,
+      ECopyVariant.CSS_RGB,
+      ECopyVariant.CSS_HSL,
+      ECopyVariant.CSS_RGB_DISPLAY_P3,
+    ],
+  },
+  {
+    id: EExportPaletteVariant.JS_OBJECT,
+    label: 'JavaScript object',
+    fileExtension: 'js',
+    availableColorProfiles: 'all',
+  },
 ]
 
 const formatJsObjectFieldName = (fieldName: string) => {

--- a/src/utils/palette/export.palette.ts
+++ b/src/utils/palette/export.palette.ts
@@ -13,7 +13,7 @@ export const exportPaletteVariants: {
   {
     id: EExportPaletteVariant.PLAINCOLOR_JSON,
     label: 'PlainColor palette JSON',
-    fileExtension: 'json',
+    fileExtension: 'plaincolorjson',
     availableColorProfiles: [ECopyVariant.HEX_LOWERCASE_WITHOUT_SHARP],
     allowCopy: true,
   },
@@ -23,6 +23,13 @@ export const exportPaletteVariants: {
     fileExtension: 'json',
     availableColorProfiles: 'all',
     allowCopy: true,
+  },
+  {
+    id: EExportPaletteVariant.APPLE_CLR,
+    label: 'Apple Color List (.clr)',
+    fileExtension: 'clr',
+    availableColorProfiles: [],
+    allowCopy: false,
   },
   {
     id: EExportPaletteVariant.CSS_VARS,
@@ -56,13 +63,6 @@ export const exportPaletteVariants: {
     fileExtension: 'js',
     availableColorProfiles: 'all',
     allowCopy: true,
-  },
-  {
-    id: EExportPaletteVariant.APPLE_CLR,
-    label: 'Apple Color List (.clr)',
-    fileExtension: 'clr',
-    availableColorProfiles: [],
-    allowCopy: false,
   },
 ]
 

--- a/src/utils/palette/import.palette.ts
+++ b/src/utils/palette/import.palette.ts
@@ -9,19 +9,21 @@ export const importPaletteVariants = [
   {
     id: EImportPaletteVariant.PLAINCOLOR_JSON,
     label: 'PlainColor JSON',
-    infoText: 'Import colors from PlainColor JSON file',
+    infoText: 'Import colors from PlainColor JSON file.',
   },
   {
     id: EImportPaletteVariant.APPLE_CLR,
     label: 'Apple Color List (.clr)',
-    infoText: 'Import colors from Apple Color List (.clr) file',
+    infoText: 'Import colors from Apple Color List (.clr) file.',
+    infoUrl: 'https://gist.github.com/chsh/f9bcb00a22cb5c5a7477757632917d25',
+    infoUrlLabel: 'CLR palette examples on GitHub',
   },
   {
     id: EImportPaletteVariant.APPLE_COLORS_PHP,
     label: 'Apple colors',
     infoText: 'Download all the default Apple colors for iOS, macOS, tvOS, visionOS, and watchOS from unofficial',
     infoUrl: 'https://github.com/phpcolor/apple-colors/tree/main/Resources/colors',
-    infoUrlLabel: 'apple-colors GitHub repository',
+    infoUrlLabel: 'phpcolor GitHub repository',
   },
   {
     id: EImportPaletteVariant.TAILWIND_COLORS_JS,

--- a/src/utils/palette/import.palette.ts
+++ b/src/utils/palette/import.palette.ts
@@ -1,8 +1,9 @@
-import { EImportPaletteVariant, IPalette } from '@/types/palette.types'
+import { EImportPaletteVariant, IPalette, IPlainColorPaletteJson } from '@/types/palette.types'
 import { open } from '@tauri-apps/plugin-dialog'
 import { readTextFile } from '@tauri-apps/plugin-fs'
 import { fetch } from '@tauri-apps/plugin-http'
 import { generateRandomUuid } from '@/utils/uuid.util'
+import { sanitizeHexInputValue } from '../sanitize.util'
 
 export const importPaletteVariants = [
   {
@@ -27,7 +28,7 @@ interface ITailwindColorsJsResponseObject {
     | string
 }
 
-export const importPalette = async (importVariant: EImportPaletteVariant): Promise<Omit<IPalette, 'id'>> => {
+export const importPalette = async (importVariant: EImportPaletteVariant): Promise<Omit<IPalette, 'id' | 'view'>> => {
   switch (importVariant) {
     case EImportPaletteVariant.PLAINCOLOR_JSON: {
       const filePath = await open({
@@ -42,8 +43,32 @@ export const importPalette = async (importVariant: EImportPaletteVariant): Promi
       }
 
       const fileContent = await readTextFile(filePath)
-      const palette = JSON.parse(fileContent) as Omit<IPalette, 'id'>
-      return { ...palette, colors: palette.colors.map((color) => ({ ...color, id: generateRandomUuid() })) }
+      const parsed = JSON.parse(fileContent) as IPlainColorPaletteJson
+
+      if (!parsed.colors || !parsed.label) {
+        throw new Error('Wrong palette format')
+      }
+
+      if (parsed.label && typeof parsed.label !== 'string') {
+        throw new Error('Wrong palette label value')
+      }
+      if (parsed.colors && !Array.isArray(parsed.colors)) {
+        throw new Error('Wrong palette colors value')
+      }
+
+      const colors = parsed.colors.filter((color) => {
+        return (
+          typeof color.label === 'string' &&
+          typeof color.hex === 'string' &&
+          (color.hex.length === 6 || color.hex.length === 8) &&
+          color.hex === sanitizeHexInputValue(color.hex)
+        )
+      })
+
+      return {
+        label: parsed.label,
+        colors: colors.map((color) => ({ id: generateRandomUuid(), label: color.label, hex: color.hex })),
+      }
     }
     case EImportPaletteVariant.TAILWIND_COLORS_JS: {
       const response = await fetch(
@@ -89,7 +114,7 @@ export const importPalette = async (importVariant: EImportPaletteVariant): Promi
         .flat()
       colors = colors.filter((color) => color.hex) // remove all colors that are not hex values
 
-      return { label: 'Tailwind CSS', colors, view: 'grid' }
+      return { label: 'Tailwind CSS', colors }
     }
   }
 }

--- a/src/utils/palette/import.palette.ts
+++ b/src/utils/palette/import.palette.ts
@@ -2,7 +2,7 @@ import { EImportPaletteVariant, IPalette } from '@/types/palette.types'
 import { open } from '@tauri-apps/plugin-dialog'
 import { readTextFile } from '@tauri-apps/plugin-fs'
 import { fetch } from '@tauri-apps/plugin-http'
-import { generateRandomUuid } from '../uuid.util'
+import { generateRandomUuid } from '@/utils/uuid.util'
 
 export const importPaletteVariants = [
   {

--- a/src/utils/palette/import.palette.ts
+++ b/src/utils/palette/import.palette.ts
@@ -41,13 +41,16 @@ export const importPaletteVariants = [
   },
 ]
 
-export const importPalette = async (importVariant: EImportPaletteVariant): Promise<TPaletteImporterResult> => {
+export const importPalette = async (
+  importVariant: EImportPaletteVariant,
+  filePath?: string
+): Promise<TPaletteImporterResult> => {
   switch (importVariant) {
     case EImportPaletteVariant.PLAINCOLOR_JSON: {
-      return plaincolorImporter()
+      return plaincolorImporter(filePath)
     }
     case EImportPaletteVariant.APPLE_CLR: {
-      return clrImporter()
+      return clrImporter(filePath)
     }
     case EImportPaletteVariant.APPLE_COLORS_PHP: {
       return appleImporter()

--- a/src/utils/palette/import.palette.ts
+++ b/src/utils/palette/import.palette.ts
@@ -2,6 +2,7 @@ import { EImportPaletteVariant, TPaletteImporterResult } from '@/types/palette.t
 import { tailwindImporter } from './importers/tailwind.importer'
 import { plaincolorImporter } from './importers/plaincolor.importer'
 import { muiImporter } from './importers/mui.importer'
+import { appleImporter } from './importers/apple.importer'
 
 export const importPaletteVariants = [
   {
@@ -11,17 +12,24 @@ export const importPaletteVariants = [
   },
   {
     id: EImportPaletteVariant.TAILWIND_COLORS_JS,
-    label: 'Tailwind CSS default colors',
-    infoText: 'Download default Tailwind CSS colors from',
+    label: 'Tailwind CSS colors',
+    infoText: 'Download all the default Tailwind CSS colors from official',
     infoUrl: 'https://github.com/tailwindlabs/tailwindcss/blob/main/src/public/colors.js',
     infoUrlLabel: 'tailwindcss GitHub repository',
   },
   {
     id: EImportPaletteVariant.MUI_COLORS_JS,
-    label: 'Material UI default colors',
-    infoText: 'Download default Material UI colors from',
+    label: 'Material UI colors',
+    infoText: 'Download all the default Material UI colors from official',
     infoUrl: 'https://github.com/mui/material-ui/tree/master/packages/mui-material/src/colors',
     infoUrlLabel: 'material-ui GitHub repository',
+  },
+  {
+    id: EImportPaletteVariant.APPLE_COLORS_PHP,
+    label: 'Apple colors',
+    infoText: 'Download all the default Apple colors for iOS, macOS, tvOS, visionOS, and watchOS from unofficial',
+    infoUrl: 'https://github.com/phpcolor/apple-colors/tree/main/Resources/colors',
+    infoUrlLabel: 'apple-colors GitHub repository',
   },
 ]
 
@@ -29,6 +37,9 @@ export const importPalette = async (importVariant: EImportPaletteVariant): Promi
   switch (importVariant) {
     case EImportPaletteVariant.PLAINCOLOR_JSON: {
       return plaincolorImporter()
+    }
+    case EImportPaletteVariant.APPLE_COLORS_PHP: {
+      return appleImporter()
     }
     case EImportPaletteVariant.TAILWIND_COLORS_JS: {
       return tailwindImporter()

--- a/src/utils/palette/import.palette.ts
+++ b/src/utils/palette/import.palette.ts
@@ -1,9 +1,7 @@
-import { EImportPaletteVariant, IPalette, IPlainColorPaletteJson } from '@/types/palette.types'
-import { open } from '@tauri-apps/plugin-dialog'
-import { readTextFile } from '@tauri-apps/plugin-fs'
-import { fetch } from '@tauri-apps/plugin-http'
-import { generateRandomUuid } from '@/utils/uuid.util'
-import { sanitizeHexInputValue } from '../sanitize.util'
+import { EImportPaletteVariant, TPaletteImporterResult } from '@/types/palette.types'
+import { tailwindImporter } from './importers/tailwind.importer'
+import { plaincolorImporter } from './importers/plaincolor.importer'
+import { muiImporter } from './importers/mui.importer'
 
 export const importPaletteVariants = [
   {
@@ -18,103 +16,25 @@ export const importPaletteVariants = [
     infoUrl: 'https://github.com/tailwindlabs/tailwindcss/blob/main/src/public/colors.js',
     infoUrlLabel: 'tailwindcss GitHub repository',
   },
+  {
+    id: EImportPaletteVariant.MUI_COLORS_JS,
+    label: 'Material UI default colors',
+    infoText: 'Download default Material UI colors from',
+    infoUrl: 'https://github.com/mui/material-ui/tree/master/packages/mui-material/src/colors',
+    infoUrlLabel: 'material-ui GitHub repository',
+  },
 ]
 
-interface ITailwindColorsJsResponseObject {
-  [color: string]:
-    | {
-        [shade: string]: string
-      }
-    | string
-}
-
-export const importPalette = async (importVariant: EImportPaletteVariant): Promise<Omit<IPalette, 'id' | 'view'>> => {
+export const importPalette = async (importVariant: EImportPaletteVariant): Promise<TPaletteImporterResult> => {
   switch (importVariant) {
     case EImportPaletteVariant.PLAINCOLOR_JSON: {
-      const filePath = await open({
-        title: 'Import palette from PlainColor JSON',
-        filters: [{ name: 'JSON', extensions: ['json'] }],
-        multiple: false,
-        directory: false,
-      })
-
-      if (!filePath) {
-        throw new Error('Action rejected')
-      }
-
-      const fileContent = await readTextFile(filePath)
-      const parsed = JSON.parse(fileContent) as IPlainColorPaletteJson
-
-      if (!parsed.colors || !parsed.label) {
-        throw new Error('Wrong palette format')
-      }
-
-      if (parsed.label && typeof parsed.label !== 'string') {
-        throw new Error('Wrong palette label value')
-      }
-      if (parsed.colors && !Array.isArray(parsed.colors)) {
-        throw new Error('Wrong palette colors value')
-      }
-
-      const colors = parsed.colors.filter((color) => {
-        return (
-          typeof color.label === 'string' &&
-          typeof color.hex === 'string' &&
-          (color.hex.length === 6 || color.hex.length === 8) &&
-          color.hex === sanitizeHexInputValue(color.hex)
-        )
-      })
-
-      return {
-        label: parsed.label,
-        colors: colors.map((color) => ({ id: generateRandomUuid(), label: color.label, hex: color.hex })),
-      }
+      return plaincolorImporter()
     }
     case EImportPaletteVariant.TAILWIND_COLORS_JS: {
-      const response = await fetch(
-        'https://raw.githubusercontent.com/tailwindlabs/tailwindcss/refs/heads/main/src/public/colors.js',
-        {
-          method: 'GET',
-        }
-      )
-      const text = await response.text()
-
-      let jsObjectStr = text.match(/export default\s*({[\s\S]*});?/)?.[1] || '' // extract {} object
-      jsObjectStr = jsObjectStr.replace(/get\s+\w+\s*\([^)]*\)\s*{[\s\S]*?return[\s\S]*?},?/g, '') // remove getters
-      jsObjectStr = jsObjectStr.replace(/,(\s*[}\]])/g, '$1') // remove trailing commas
-      const json = jsObjectStr.replace(/(\w+):/g, '"$1":').replace(/'/g, '"') // transform js object to json
-      const jsObject = JSON.parse(json) as ITailwindColorsJsResponseObject
-
-      let colors = Object.entries(jsObject)
-        .map(([colorKey, colorValue]) => {
-          if (typeof colorValue === 'string') {
-            return [
-              {
-                id: generateRandomUuid(),
-                label: colorKey,
-                hex:
-                  colorValue.startsWith('#') && (colorValue.length === 7 || colorValue.length === 9)
-                    ? colorValue.replace('#', '').toLowerCase()
-                    : '',
-              },
-            ]
-          } else {
-            return Object.entries(colorValue).map(([shadeKey, shadeValue]) => {
-              return {
-                id: generateRandomUuid(),
-                label: `${colorKey}-${shadeKey}`,
-                hex:
-                  shadeValue.startsWith('#') && (shadeValue.length === 7 || shadeValue.length === 9)
-                    ? shadeValue.replace('#', '').toLowerCase()
-                    : '',
-              }
-            })
-          }
-        })
-        .flat()
-      colors = colors.filter((color) => color.hex) // remove all colors that are not hex values
-
-      return { label: 'Tailwind CSS', colors }
+      return tailwindImporter()
+    }
+    case EImportPaletteVariant.MUI_COLORS_JS: {
+      return muiImporter()
     }
   }
 }

--- a/src/utils/palette/import.palette.ts
+++ b/src/utils/palette/import.palette.ts
@@ -3,12 +3,25 @@ import { tailwindImporter } from './importers/tailwind.importer'
 import { plaincolorImporter } from './importers/plaincolor.importer'
 import { muiImporter } from './importers/mui.importer'
 import { appleImporter } from './importers/apple.importer'
+import { clrImporter } from './importers/clr.importer'
 
 export const importPaletteVariants = [
   {
     id: EImportPaletteVariant.PLAINCOLOR_JSON,
     label: 'PlainColor JSON',
     infoText: 'Import colors from PlainColor JSON file',
+  },
+  {
+    id: EImportPaletteVariant.APPLE_CLR,
+    label: 'Apple Color List (.clr)',
+    infoText: 'Import colors from Apple Color List (.clr) file',
+  },
+  {
+    id: EImportPaletteVariant.APPLE_COLORS_PHP,
+    label: 'Apple colors',
+    infoText: 'Download all the default Apple colors for iOS, macOS, tvOS, visionOS, and watchOS from unofficial',
+    infoUrl: 'https://github.com/phpcolor/apple-colors/tree/main/Resources/colors',
+    infoUrlLabel: 'apple-colors GitHub repository',
   },
   {
     id: EImportPaletteVariant.TAILWIND_COLORS_JS,
@@ -24,19 +37,15 @@ export const importPaletteVariants = [
     infoUrl: 'https://github.com/mui/material-ui/tree/master/packages/mui-material/src/colors',
     infoUrlLabel: 'material-ui GitHub repository',
   },
-  {
-    id: EImportPaletteVariant.APPLE_COLORS_PHP,
-    label: 'Apple colors',
-    infoText: 'Download all the default Apple colors for iOS, macOS, tvOS, visionOS, and watchOS from unofficial',
-    infoUrl: 'https://github.com/phpcolor/apple-colors/tree/main/Resources/colors',
-    infoUrlLabel: 'apple-colors GitHub repository',
-  },
 ]
 
 export const importPalette = async (importVariant: EImportPaletteVariant): Promise<TPaletteImporterResult> => {
   switch (importVariant) {
     case EImportPaletteVariant.PLAINCOLOR_JSON: {
       return plaincolorImporter()
+    }
+    case EImportPaletteVariant.APPLE_CLR: {
+      return clrImporter()
     }
     case EImportPaletteVariant.APPLE_COLORS_PHP: {
       return appleImporter()

--- a/src/utils/palette/importers/apple.importer.ts
+++ b/src/utils/palette/importers/apple.importer.ts
@@ -1,0 +1,81 @@
+import { IColor } from '@/types/color.types'
+import { TPaletteImporterResult } from '@/types/palette.types'
+import { generateRandomUuid } from '@/utils/uuid.util'
+import { fetch } from '@tauri-apps/plugin-http'
+
+const getFiles = async () => {
+  const response = await fetch('https://api.github.com/repos/phpcolor/apple-colors/contents/Resources/colors', {
+    method: 'GET',
+  })
+  const fileListJson = (await response.json()) as { name: string; download_url: string }[]
+
+  return fileListJson
+    .filter((file) => file.name.endsWith('.php'))
+    .map((file) => ({ fileName: file.name, fileUrl: file.download_url }))
+}
+
+const capitalize = (word: string) => {
+  return word.charAt(0).toUpperCase() + word.slice(1)
+}
+
+const processFile = async (fileName: string, fileUrl: string): Promise<IColor[]> => {
+  const response = await fetch(fileUrl, {
+    method: 'GET',
+  })
+  const phpContent = await response.text()
+
+  const regex = /'(\w+)' => \['#([A-Fa-f0-9]{6})'/g
+  const categoriesRegex = /'(light|dark)' => \[/g
+
+  // Extract categories for matching light/dark sections.
+  const categories: string[] = [...phpContent.matchAll(categoriesRegex)].map((match) => match[1])
+
+  // Extract colors with names and hex codes.
+  const matches = [...phpContent.matchAll(regex)]
+  const results: IColor[] = []
+
+  let currentCategoryIndex = -1
+
+  matches.forEach((match) => {
+    const [_, name, hex] = match
+    // Determine the category for the color.
+    const lineIndex = phpContent.indexOf(match[0])
+    if (
+      currentCategoryIndex < categories.length - 1 &&
+      lineIndex > phpContent.indexOf(categories[currentCategoryIndex + 1])
+    ) {
+      currentCategoryIndex++
+    }
+    const category = categories[currentCategoryIndex]
+    results.push({
+      id: generateRandomUuid(),
+      label: `${fileName} ${capitalize(name)}` + (category ? ` ${capitalize(category)}` : ''),
+      hex: hex.toLowerCase(),
+    })
+  })
+
+  return results
+}
+
+export const appleImporter = async (): Promise<TPaletteImporterResult> => {
+  const files = await getFiles()
+
+  const fileResults = await Promise.all(
+    files.map((file) => processFile(file.fileName.replace('.php', ''), file.fileUrl))
+  )
+
+  const colors = fileResults
+    .flat()
+    .filter((c) => c.hex.length === 6 || c.hex.length === 8)
+    .toSorted((a, b) => {
+      if (a.label < b.label) {
+        return -1
+      }
+      if (a.label > b.label) {
+        return 1
+      }
+      return 0
+    })
+
+  return { label: 'Apple', colors }
+}

--- a/src/utils/palette/importers/clr.importer.ts
+++ b/src/utils/palette/importers/clr.importer.ts
@@ -2,6 +2,7 @@ import { IColor } from '@/types/color.types'
 import { TPaletteImporterResult } from '@/types/palette.types'
 import { invokeLoadClrFile } from '@/utils/cmd/clr.cmd.util'
 import { generateRandomUuid } from '@/utils/uuid.util'
+import { open } from '@tauri-apps/plugin-dialog'
 
 export interface IClrResponseObject {
   paletteName: string
@@ -10,8 +11,25 @@ export interface IClrResponseObject {
   }
 }
 
-export const clrImporter = async (): Promise<TPaletteImporterResult> => {
-  const json = (await invokeLoadClrFile()).trim()
+export const clrImporter = async (filePath?: string): Promise<TPaletteImporterResult> => {
+  if (!filePath) {
+    const file = await open({
+      title: 'Import palette from Apple Color List (.clr) file',
+      filters: [{ name: 'Apple Color List', extensions: ['clr'] }],
+      multiple: false,
+      directory: false,
+    })
+
+    if (file) {
+      filePath = file
+    }
+  }
+
+  if (!filePath) {
+    throw new Error('Action rejected')
+  }
+
+  const json = (await invokeLoadClrFile(filePath)).trim()
 
   if (!json.startsWith('{') || !json.endsWith('}')) {
     throw new Error(json)

--- a/src/utils/palette/importers/clr.importer.ts
+++ b/src/utils/palette/importers/clr.importer.ts
@@ -3,7 +3,7 @@ import { TPaletteImporterResult } from '@/types/palette.types'
 import { invokeLoadClrFile } from '@/utils/cmd/clr.cmd.util'
 import { generateRandomUuid } from '@/utils/uuid.util'
 
-interface IClrResponseObject {
+export interface IClrResponseObject {
   paletteName: string
   colorList: {
     [color: string]: string

--- a/src/utils/palette/importers/clr.importer.ts
+++ b/src/utils/palette/importers/clr.importer.ts
@@ -1,0 +1,29 @@
+import { IColor } from '@/types/color.types'
+import { TPaletteImporterResult } from '@/types/palette.types'
+import { invokeLoadClrFile } from '@/utils/cmd/clr.cmd.util'
+import { generateRandomUuid } from '@/utils/uuid.util'
+
+interface IClrResponseObject {
+  paletteName: string
+  colorList: {
+    [color: string]: string
+  }
+}
+
+export const clrImporter = async (): Promise<TPaletteImporterResult> => {
+  const json = (await invokeLoadClrFile()).trim()
+
+  if (!json.startsWith('{') || !json.endsWith('}')) {
+    throw new Error(json)
+  }
+
+  const obj = JSON.parse(json) as IClrResponseObject
+
+  const colors = Object.entries(obj.colorList).map<IColor>(([label, hexWithSharp]) => ({
+    id: generateRandomUuid(),
+    label,
+    hex: hexWithSharp.replace('#', ''),
+  }))
+
+  return { label: obj.paletteName, colors }
+}

--- a/src/utils/palette/importers/clr.importer.ts
+++ b/src/utils/palette/importers/clr.importer.ts
@@ -25,5 +25,5 @@ export const clrImporter = async (): Promise<TPaletteImporterResult> => {
     hex: hexWithSharp.replace('#', ''),
   }))
 
-  return { label: obj.paletteName, colors }
+  return { label: decodeURIComponent(obj.paletteName), colors }
 }

--- a/src/utils/palette/importers/mui.importer.ts
+++ b/src/utils/palette/importers/mui.importer.ts
@@ -1,0 +1,49 @@
+import { TPaletteImporterResult } from '@/types/palette.types'
+import { generateRandomUuid } from '@/utils/uuid.util'
+import { fetch } from '@tauri-apps/plugin-http'
+
+const getFiles = async () => {
+  const response = await fetch(
+    'https://raw.githubusercontent.com/mui/material-ui/refs/heads/master/packages/mui-material/src/colors/index.js',
+    {
+      method: 'GET',
+    }
+  )
+  const fileListText = await response.text()
+
+  const regex = /'\.\/(.*?)'/g
+  const matches = [...fileListText.matchAll(regex)]
+
+  return matches.map((match) => ({
+    fileName: match[1],
+    fileUrl: `https://raw.githubusercontent.com/mui/material-ui/refs/heads/master/packages/mui-material/src/colors/${match[1]}.js`,
+  }))
+}
+
+const processFile = async (fileName: string, fileUrl: string): Promise<{ key: string; value: string }[]> => {
+  const response = await fetch(fileUrl, {
+    method: 'GET',
+  })
+  const text = await response.text()
+
+  const regex = /(\w+):\s*'#([0-9a-fA-F]+)'/g // Regex to capture keys and hex values without the '#'
+  const matches = [...text.matchAll(regex)]
+
+  return matches.map((match) => ({
+    key: `${fileName} ${match[1]}`, // Extract the key (label)
+    value: match[2], // Extract the hex value without the '#'
+  }))
+}
+
+export const muiImporter = async (): Promise<TPaletteImporterResult> => {
+  const files = await getFiles()
+
+  const fileResults = await Promise.all(files.map((file) => processFile(file.fileName, file.fileUrl)))
+
+  const colors = fileResults
+    .flat()
+    .filter((c) => c.value.length === 6 || c.value.length === 8)
+    .map((c) => ({ id: generateRandomUuid(), label: c.key, hex: c.value }))
+
+  return { label: 'Material UI', colors }
+}

--- a/src/utils/palette/importers/plaincolor.importer.ts
+++ b/src/utils/palette/importers/plaincolor.importer.ts
@@ -4,13 +4,19 @@ import { readTextFile } from '@tauri-apps/plugin-fs'
 import { generateRandomUuid } from '@/utils/uuid.util'
 import { sanitizeHexInputValue } from '@/utils/sanitize.util'
 
-export const plaincolorImporter = async (): Promise<TPaletteImporterResult> => {
-  const filePath = await open({
-    title: 'Import palette from PlainColor JSON',
-    filters: [{ name: 'JSON', extensions: ['json'] }],
-    multiple: false,
-    directory: false,
-  })
+export const plaincolorImporter = async (filePath?: string): Promise<TPaletteImporterResult> => {
+  if (!filePath) {
+    const file = await open({
+      title: 'Import palette from PlainColor JSON',
+      filters: [{ name: 'PlainColor JSON', extensions: ['plaincolorjson'] }],
+      multiple: false,
+      directory: false,
+    })
+
+    if (file) {
+      filePath = file
+    }
+  }
 
   if (!filePath) {
     throw new Error('Action rejected')

--- a/src/utils/palette/importers/plaincolor.importer.ts
+++ b/src/utils/palette/importers/plaincolor.importer.ts
@@ -1,0 +1,46 @@
+import { TPaletteImporterResult, TPlainColorPaletteJson } from '@/types/palette.types'
+import { open } from '@tauri-apps/plugin-dialog'
+import { readTextFile } from '@tauri-apps/plugin-fs'
+import { generateRandomUuid } from '@/utils/uuid.util'
+import { sanitizeHexInputValue } from '@/utils/sanitize.util'
+
+export const plaincolorImporter = async (): Promise<TPaletteImporterResult> => {
+  const filePath = await open({
+    title: 'Import palette from PlainColor JSON',
+    filters: [{ name: 'JSON', extensions: ['json'] }],
+    multiple: false,
+    directory: false,
+  })
+
+  if (!filePath) {
+    throw new Error('Action rejected')
+  }
+
+  const fileContent = await readTextFile(filePath)
+  const parsed = JSON.parse(fileContent) as TPlainColorPaletteJson
+
+  if (!parsed.colors || !parsed.label) {
+    throw new Error('Wrong palette format')
+  }
+
+  if (parsed.label && typeof parsed.label !== 'string') {
+    throw new Error('Wrong palette label value')
+  }
+  if (parsed.colors && !Array.isArray(parsed.colors)) {
+    throw new Error('Wrong palette colors value')
+  }
+
+  const colors = parsed.colors.filter((color) => {
+    return (
+      typeof color.label === 'string' &&
+      typeof color.hex === 'string' &&
+      (color.hex.length === 6 || color.hex.length === 8) &&
+      color.hex === sanitizeHexInputValue(color.hex)
+    )
+  })
+
+  return {
+    label: parsed.label,
+    colors: colors.map((color) => ({ id: generateRandomUuid(), label: color.label, hex: color.hex })),
+  }
+}

--- a/src/utils/palette/importers/tailwind.importer.ts
+++ b/src/utils/palette/importers/tailwind.importer.ts
@@ -2,7 +2,7 @@ import { TPaletteImporterResult } from '@/types/palette.types'
 import { generateRandomUuid } from '@/utils/uuid.util'
 import { fetch } from '@tauri-apps/plugin-http'
 
-interface ITailwindColorsJsResponseObject {
+interface ITailwindResponseObject {
   [color: string]:
     | {
         [shade: string]: string
@@ -23,7 +23,7 @@ export const tailwindImporter = async (): Promise<TPaletteImporterResult> => {
   jsObjectStr = jsObjectStr.replace(/get\s+\w+\s*\([^)]*\)\s*{[\s\S]*?return[\s\S]*?},?/g, '') // remove getters
   jsObjectStr = jsObjectStr.replace(/,(\s*[}\]])/g, '$1') // remove trailing commas
   const json = jsObjectStr.replace(/(\w+):/g, '"$1":').replace(/'/g, '"') // transform js object to json
-  const jsObject = JSON.parse(json) as ITailwindColorsJsResponseObject
+  const jsObject = JSON.parse(json) as ITailwindResponseObject
 
   let colors = Object.entries(jsObject)
     .map(([colorKey, colorValue]) => {

--- a/src/utils/palette/importers/tailwind.importer.ts
+++ b/src/utils/palette/importers/tailwind.importer.ts
@@ -1,0 +1,58 @@
+import { TPaletteImporterResult } from '@/types/palette.types'
+import { generateRandomUuid } from '@/utils/uuid.util'
+import { fetch } from '@tauri-apps/plugin-http'
+
+interface ITailwindColorsJsResponseObject {
+  [color: string]:
+    | {
+        [shade: string]: string
+      }
+    | string
+}
+
+export const tailwindImporter = async (): Promise<TPaletteImporterResult> => {
+  const response = await fetch(
+    'https://raw.githubusercontent.com/tailwindlabs/tailwindcss/refs/heads/main/src/public/colors.js',
+    {
+      method: 'GET',
+    }
+  )
+  const text = await response.text()
+
+  let jsObjectStr = text.match(/export default\s*({[\s\S]*});?/)?.[1] || '' // extract {} object
+  jsObjectStr = jsObjectStr.replace(/get\s+\w+\s*\([^)]*\)\s*{[\s\S]*?return[\s\S]*?},?/g, '') // remove getters
+  jsObjectStr = jsObjectStr.replace(/,(\s*[}\]])/g, '$1') // remove trailing commas
+  const json = jsObjectStr.replace(/(\w+):/g, '"$1":').replace(/'/g, '"') // transform js object to json
+  const jsObject = JSON.parse(json) as ITailwindColorsJsResponseObject
+
+  let colors = Object.entries(jsObject)
+    .map(([colorKey, colorValue]) => {
+      if (typeof colorValue === 'string') {
+        return [
+          {
+            id: generateRandomUuid(),
+            label: colorKey,
+            hex:
+              colorValue.startsWith('#') && (colorValue.length === 7 || colorValue.length === 9)
+                ? colorValue.replace('#', '').toLowerCase()
+                : '',
+          },
+        ]
+      } else {
+        return Object.entries(colorValue).map(([shadeKey, shadeValue]) => {
+          return {
+            id: generateRandomUuid(),
+            label: `${colorKey}-${shadeKey}`,
+            hex:
+              shadeValue.startsWith('#') && (shadeValue.length === 7 || shadeValue.length === 9)
+                ? shadeValue.replace('#', '').toLowerCase()
+                : '',
+          }
+        })
+      }
+    })
+    .flat()
+  colors = colors.filter((color) => color.hex) // remove all colors that are not hex values
+
+  return { label: 'Tailwind CSS', colors }
+}

--- a/src/utils/palette/index.ts
+++ b/src/utils/palette/index.ts
@@ -1,0 +1,60 @@
+import { IPalette } from '@/types/palette.types'
+import { generateRandomUuid } from '@/utils/uuid.util'
+import { generateColorLabel } from '@/utils/color'
+
+// Trending 1 and 2 -  https://coolors.co/palettes/trending
+const predefinedPalette1 = ['606c38', '283618', 'fefae0', 'dda15e', 'bc6c25']
+const predefinedPalette2 = ['8ecae6', '219ebc', '023047', 'ffb703', 'fb8500']
+
+// 10 shades of P!NK - https://coolors.co/palette/590d22-800f2f-a4133c-c9184a-ff4d6d-ff758f-ff8fa3-ffb3c1-ffccd5-fff0f3
+const predefinedPalette3 = [
+  '590d22',
+  '800f2f',
+  'a4133c',
+  'c9184a',
+  'ff4d6d',
+  'ff758f',
+  'ff8fa3',
+  'ffb3c1',
+  'ffccd5',
+  'fff0f3',
+]
+
+// All time popular - https://colorhunt.co/palettes/popular
+const predefinedPalette4 = ['222831', '393e46', '00adb5', 'eeeeee']
+
+// Palette of the month - https://colorhunt.co/palettes/popular
+const predefinedPalette5 = ['86a788', 'fffdec', 'ffe2e2', 'ffcfcf']
+
+export const predefinedPalettes: IPalette[] = [
+  {
+    id: generateRandomUuid(),
+    label: 'Trending 1',
+    colors: predefinedPalette1.map((hex) => ({ id: generateRandomUuid(), hex, label: generateColorLabel(hex) })),
+    view: 'list',
+  },
+  {
+    id: generateRandomUuid(),
+    label: 'Trending 2',
+    colors: predefinedPalette2.map((hex) => ({ id: generateRandomUuid(), hex, label: generateColorLabel(hex) })),
+    view: 'list',
+  },
+  {
+    id: generateRandomUuid(),
+    label: '10 shades of P!NK',
+    colors: predefinedPalette3.map((hex) => ({ id: generateRandomUuid(), hex, label: generateColorLabel(hex) })),
+    view: 'grid',
+  },
+  {
+    id: generateRandomUuid(),
+    label: 'All time popular',
+    colors: predefinedPalette4.map((hex) => ({ id: generateRandomUuid(), hex, label: generateColorLabel(hex) })),
+    view: 'list',
+  },
+  {
+    id: generateRandomUuid(),
+    label: 'Palette of the month',
+    colors: predefinedPalette5.map((hex) => ({ id: generateRandomUuid(), hex, label: generateColorLabel(hex) })),
+    view: 'list',
+  },
+]

--- a/src/utils/palette/index.ts
+++ b/src/utils/palette/index.ts
@@ -2,12 +2,11 @@ import { IPalette } from '@/types/palette.types'
 import { generateRandomUuid } from '@/utils/uuid.util'
 import { generateColorLabel } from '@/utils/color'
 
-// Trending 1 and 2 -  https://coolors.co/palettes/trending
+// Trending -  https://coolors.co/palettes/trending
 const predefinedPalette1 = ['606c38', '283618', 'fefae0', 'dda15e', 'bc6c25']
-const predefinedPalette2 = ['8ecae6', '219ebc', '023047', 'ffb703', 'fb8500']
 
 // 10 shades of P!NK - https://coolors.co/palette/590d22-800f2f-a4133c-c9184a-ff4d6d-ff758f-ff8fa3-ffb3c1-ffccd5-fff0f3
-const predefinedPalette3 = [
+const predefinedPalette2 = [
   '590d22',
   '800f2f',
   'a4133c',
@@ -21,40 +20,25 @@ const predefinedPalette3 = [
 ]
 
 // All time popular - https://colorhunt.co/palettes/popular
-const predefinedPalette4 = ['222831', '393e46', '00adb5', 'eeeeee']
-
-// Palette of the month - https://colorhunt.co/palettes/popular
-const predefinedPalette5 = ['86a788', 'fffdec', 'ffe2e2', 'ffcfcf']
+const predefinedPalette3 = ['222831', '393e46', '00adb5', 'eeeeee']
 
 export const predefinedPalettes: IPalette[] = [
   {
     id: generateRandomUuid(),
-    label: 'Trending 1',
+    label: 'Trending',
     colors: predefinedPalette1.map((hex) => ({ id: generateRandomUuid(), hex, label: generateColorLabel(hex) })),
     view: 'list',
   },
   {
     id: generateRandomUuid(),
-    label: 'Trending 2',
-    colors: predefinedPalette2.map((hex) => ({ id: generateRandomUuid(), hex, label: generateColorLabel(hex) })),
-    view: 'list',
-  },
-  {
-    id: generateRandomUuid(),
     label: '10 shades of P!NK',
-    colors: predefinedPalette3.map((hex) => ({ id: generateRandomUuid(), hex, label: generateColorLabel(hex) })),
+    colors: predefinedPalette2.map((hex) => ({ id: generateRandomUuid(), hex, label: generateColorLabel(hex) })),
     view: 'grid',
   },
   {
     id: generateRandomUuid(),
     label: 'All time popular',
-    colors: predefinedPalette4.map((hex) => ({ id: generateRandomUuid(), hex, label: generateColorLabel(hex) })),
-    view: 'list',
-  },
-  {
-    id: generateRandomUuid(),
-    label: 'Palette of the month',
-    colors: predefinedPalette5.map((hex) => ({ id: generateRandomUuid(), hex, label: generateColorLabel(hex) })),
+    colors: predefinedPalette3.map((hex) => ({ id: generateRandomUuid(), hex, label: generateColorLabel(hex) })),
     view: 'list',
   },
 ]

--- a/src/utils/sanitize.util.ts
+++ b/src/utils/sanitize.util.ts
@@ -5,7 +5,7 @@ export const sanitizeLabel = (label: string) => {
 export const sanitizeHexInputValue = (text: string) => {
   let sanitized = text.replace(/[^0-9a-fA-F]/g, '').slice(0, 8)
 
-  return sanitized.toUpperCase()
+  return sanitized.toLowerCase()
 }
 
 export const sanitizeHexInputBlur = (text: string) => {

--- a/src/utils/sanitize.util.ts
+++ b/src/utils/sanitize.util.ts
@@ -1,0 +1,52 @@
+export const sanitizeLabel = (label: string) => {
+  return label.trim().replace(/\s\s+/g, ' ')
+}
+
+export const sanitizeHexInputValue = (text: string) => {
+  let sanitized = text.replace(/[^0-9a-fA-F]/g, '').slice(0, 8)
+
+  return sanitized.toUpperCase()
+}
+
+export const sanitizeHexInputBlur = (text: string) => {
+  let sanitized = sanitizeHexInputValue(text)
+
+  if (sanitized === '') {
+    return '000000'
+  }
+
+  if (sanitized.length === 7) {
+    sanitized = sanitized.slice(0, 6)
+  }
+
+  // If the input length is less than 6, repeat it to fill 6 characters
+  if (sanitized.length < 6) {
+    sanitized = sanitized.repeat(6).slice(0, 6)
+  }
+
+  return sanitized
+}
+
+export const sanitizeRgbInputValue = (text: string, maxValue = 255) => {
+  // Remove non-numeric characters
+  let sanitized = text.replace(/[^0-9]/g, '')
+
+  // Remove leading zeros unless the input is exactly "0"
+  sanitized = sanitized.replace(/^0+(?!$)/, '')
+
+  // Limit the input to a maximum of 3 digits
+  sanitized = sanitized.slice(0, 3)
+
+  // Ensure the value does not exceed 255
+  if (sanitized !== '' && parseInt(sanitized, 10) > maxValue) {
+    return maxValue.toString()
+  }
+
+  return sanitized
+}
+
+export const sanitizeRgbInputBlur = (text: string) => {
+  if (text === '') return '0'
+
+  return text
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1046,6 +1046,11 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
 
+react-merge-refs@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-2.1.1.tgz#e46763f8f1b881c0226ee54a1a2a10ffefba0233"
+  integrity sha512-jLQXJ/URln51zskhgppGJ2ub7b2WFKGq3cl3NYKtlHoTG+dN2q7EzWrn3hN3EgPsTMvpR9tpq5ijdp7YwFZkag==
+
 react-refresh@^0.14.2:
   version "0.14.2"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.2.tgz#3833da01ce32da470f1f936b9d477da5c7028bf9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -576,6 +576,13 @@
   dependencies:
     "@tauri-apps/api" "^2.0.0"
 
+"@tauri-apps/plugin-deep-link@~2":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@tauri-apps/plugin-deep-link/-/plugin-deep-link-2.2.0.tgz#78c6501aa5c136ba85c85c7de13e64f2a6219124"
+  integrity sha512-H6mkxr2KZ3XJcKL44tiq6cOjCw9DL8OgU1xjn3j26Qsn+H/roPFiyhR7CHuB8Ar+sQFj4YVlfmJwtBajK2FETQ==
+  dependencies:
+    "@tauri-apps/api" "^2.0.0"
+
 "@tauri-apps/plugin-dialog@~2":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@tauri-apps/plugin-dialog/-/plugin-dialog-2.2.0.tgz#2f7b841a982820adbc9c182e0e95acd8d90aa6fc"


### PR DESCRIPTION
# v1.0.9 TODO

### 🚀 New features
- [x] Edit color: Add inputs for values (hex, r, g, b, alpha)
- [x] <a href="https://github.com/ModuleArt/plain-color/pull/9#issuecomment-2597423246">Add support for Apple Color List (.clr) file format</a>
  - [x] Import
  - [x] Export
- [x] Material UI colors palette importer ([source](https://github.com/mui/material-ui/tree/master/packages/mui-material/src/colors))
- [x] Apple colors palette importer ([source](https://github.com/phpcolor/apple-colors/tree/main/Resources/colors))
- [x] File Associations:
  - [x] Open with PlainColor for `.plaincolorjson` files
  - [x] Open with PlainColor for `.clr` files
  - [x] Drag & Drop to PlainColor window
  - [x] Drag & Drop to macOS dock

### 💅 Polishing
- [x] Automatically generate color label on color change if the custom label is not set (for colors created with + button)
- [x] Sanitize color & palette labels
- [x] Animation on export palette content copied
- [x] Picker: Pinch to zoom
- [x] Add default colors & palettes
- [x] Export palette: Add relations between export variant and color formats (available color formats depend on selected export variant)
- [x] Disable horizontal elastic scrolling behavior
- [x] Check if PlainColor palette JSON is correctly typed so it cannot break the app
- [x] Hide context menu on scroll
- [x] Add custom context menu for inputs (Cut, Copy, Paste)

### 🐞 Bug fixes
- [x] Fix: Color/Palette name white-space
- [x] Fix context menu height on different window heights
- [x] Fix: `Cmd+X`, `Cmd+C`, `Cmd+V`, `Cmd+A` not working
- [x] Fix: Do not allow to save empty color name or palette name